### PR TITLE
Toggle code block as one

### DIFF
--- a/packages/slate-plugins/src/elements/code/components/ToolbarCode.tsx
+++ b/packages/slate-plugins/src/elements/code/components/ToolbarCode.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { ToolbarButton } from 'common';
+import { ToolbarElementProps } from 'common/types';
+import { useSlate } from 'slate-react';
+import { isBlockActive } from '../../queries';
+import { toggleCode } from '../transforms';
+import { CODE } from '../types';
+
+export const ToolbarCode = (props: ToolbarElementProps) => {
+  const editor = useSlate();
+
+  return (
+    <ToolbarButton
+      {...props}
+      active={isBlockActive(editor, CODE)}
+      onMouseDown={(event: Event) => {
+        event.preventDefault();
+
+        toggleCode(editor);
+      }}
+    />
+  );
+};

--- a/packages/slate-plugins/src/elements/code/components/index.ts
+++ b/packages/slate-plugins/src/elements/code/components/index.ts
@@ -1,1 +1,2 @@
 export * from './CodeElement';
+export * from './ToolbarCode';

--- a/packages/slate-plugins/src/elements/code/index.ts
+++ b/packages/slate-plugins/src/elements/code/index.ts
@@ -1,3 +1,5 @@
 export * from './CodePlugin';
+export * from './components';
 export * from './renderElementCode';
+export * from './transforms';
 export * from './types';

--- a/packages/slate-plugins/src/elements/code/transforms/index.ts
+++ b/packages/slate-plugins/src/elements/code/transforms/index.ts
@@ -1,0 +1,1 @@
+export * from './toggleCode';

--- a/packages/slate-plugins/src/elements/code/transforms/toggleCode.ts
+++ b/packages/slate-plugins/src/elements/code/transforms/toggleCode.ts
@@ -1,0 +1,16 @@
+import { Editor, Transforms } from 'slate';
+import { isBlockActive } from '../../queries';
+import { CODE } from '../types';
+
+export const toggleCode = (editor: Editor) => {
+  if (isBlockActive(editor, CODE)) {
+    Transforms.unwrapNodes(editor, {
+      match: node => node.type === CODE,
+    });
+  } else {
+    Transforms.wrapNodes(editor, {
+      type: CODE,
+      children: [],
+    });
+  }
+};

--- a/stories/plugins/elements.stories.tsx
+++ b/stories/plugins/elements.stories.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import {
+  Code,
   FormatListBulleted,
   FormatListNumbered,
   FormatQuote,
@@ -13,6 +14,7 @@ import { Slate, withReact } from 'slate-react';
 import {
   BLOCKQUOTE,
   BlockquotePlugin,
+  CodePlugin,
   EditablePlugins,
   HeadingPlugin,
   HeadingToolbar,
@@ -21,6 +23,7 @@ import {
   ListType,
   ParagraphPlugin,
   ToolbarBlock,
+  ToolbarCode,
   ToolbarList,
   withBlock,
   withBreakEmptyReset,
@@ -36,6 +39,7 @@ export default {
     BlockquotePlugin,
     ListPlugin,
     ParagraphPlugin,
+    CodePlugin,
   },
 };
 
@@ -50,6 +54,7 @@ export const BlockPlugins = () => {
   if (boolean('HeadingPlugin', true)) plugins.push(HeadingPlugin());
   if (boolean('BlockquotePlugin', true)) plugins.push(BlockquotePlugin());
   if (boolean('ListPlugin', true)) plugins.push(ListPlugin());
+  if (boolean('CodePlugin', true)) plugins.push(CodePlugin());
 
   const createReactEditor = () => () => {
     const [value, setValue] = useState(initialValueRichText);
@@ -84,6 +89,7 @@ export const BlockPlugins = () => {
             icon={<FormatListNumbered />}
           />
           <ToolbarBlock format={BLOCKQUOTE} icon={<FormatQuote />} />
+          <ToolbarCode icon={<Code />} />
         </HeadingToolbar>
         <EditablePlugins
           plugins={plugins}


### PR DESCRIPTION
The default toggleBlock function creates several code blocks if there are multiple paragraphs selected. This fix creates a toggleCode function that just wraps the whole selection in a code block - or unwraps if it is already in a block.

It's the behavior we want from the code block - so I just created a PR in case it is of general interest. The toggle-part with wrap + unwrap is pretty general - maybe it could be made into some kind of alternative toggleBlock thing? withBlock could possibly expose two alternative toggle functions?