### PR TITLE
Add superscript and subscript plugins

### DIFF
--- a/packages/slate-plugins/src/marks/components/ToolbarMark.tsx
+++ b/packages/slate-plugins/src/marks/components/ToolbarMark.tsx
@@ -3,12 +3,16 @@ import { ToolbarButton } from 'common';
 import { ToolbarFormatProps } from 'common/types';
 import { useSlate } from 'slate-react';
 import { isMarkActive } from '../queries';
-import { toggleMark } from '../transforms/toggleMark';
+import { clearMark, toggleMark } from '../transforms';
 
 /**
  * Toolbar button to toggle mark.
  */
-export const ToolbarMark = ({ format, ...props }: ToolbarFormatProps) => {
+export const ToolbarMark = ({
+  format,
+  clear,
+  ...props
+}: ToolbarFormatProps) => {
   const editor = useSlate();
 
   return (
@@ -17,6 +21,9 @@ export const ToolbarMark = ({ format, ...props }: ToolbarFormatProps) => {
       active={isMarkActive(editor, format)}
       onMouseDown={(event: Event) => {
         event.preventDefault();
+        if (clear) {
+          clearMark(editor, clear);
+        }
         toggleMark(editor, format);
       }}
     />

--- a/packages/slate-plugins/src/marks/index.ts
+++ b/packages/slate-plugins/src/marks/index.ts
@@ -6,6 +6,7 @@ export * from './italic';
 export * from './onKeyDownMark';
 export * from './queries';
 export * from './strikethrough';
+export * from './superscript';
 export * from './transforms';
 export * from './types';
 export * from './underline';

--- a/packages/slate-plugins/src/marks/index.ts
+++ b/packages/slate-plugins/src/marks/index.ts
@@ -6,6 +6,7 @@ export * from './italic';
 export * from './onKeyDownMark';
 export * from './queries';
 export * from './strikethrough';
+export * from './subscript';
 export * from './superscript';
 export * from './transforms';
 export * from './types';

--- a/packages/slate-plugins/src/marks/onKeyDownMark.ts
+++ b/packages/slate-plugins/src/marks/onKeyDownMark.ts
@@ -1,14 +1,18 @@
 import isHotkey from 'is-hotkey';
 import { Editor } from 'slate';
-import { toggleMark } from './transforms/toggleMark';
+import { clearMark, toggleMark } from './transforms';
 import { OnKeyDownMarkOptions } from './types';
 
-export const onKeyDownMark = ({ mark, hotkey }: OnKeyDownMarkOptions) => (
-  e: any,
-  editor: Editor
-) => {
+export const onKeyDownMark = ({
+  mark,
+  clear,
+  hotkey,
+}: OnKeyDownMarkOptions) => (e: any, editor: Editor) => {
   if (isHotkey(hotkey, e)) {
     e.preventDefault();
     toggleMark(editor, mark);
+    if (clear) {
+      clearMark(editor, clear);
+    }
   }
 };

--- a/packages/slate-plugins/src/marks/subscript/SubscriptPlugin.ts
+++ b/packages/slate-plugins/src/marks/subscript/SubscriptPlugin.ts
@@ -1,5 +1,6 @@
 import { SlatePlugin } from 'types';
 import { onKeyDownMark } from '../onKeyDownMark';
+import { MARK_SUPERSCRIPT } from '../superscript/types';
 import { deserializeSubscript } from './deserializeSubscript';
 import { renderLeafSubscript } from './renderLeafSubscript';
 import { MARK_SUBSCRIPT, SubscriptPluginOptions } from './types';
@@ -8,6 +9,10 @@ export const SubscriptPlugin = ({
   hotkey = 'mod+,',
 }: SubscriptPluginOptions = {}): SlatePlugin => ({
   renderLeaf: renderLeafSubscript(),
-  onKeyDown: onKeyDownMark({ mark: MARK_SUBSCRIPT, hotkey }),
+  onKeyDown: onKeyDownMark({
+    mark: MARK_SUBSCRIPT,
+    clear: MARK_SUPERSCRIPT,
+    hotkey,
+  }),
   deserialize: deserializeSubscript(),
 });

--- a/packages/slate-plugins/src/marks/subscript/SubscriptPlugin.ts
+++ b/packages/slate-plugins/src/marks/subscript/SubscriptPlugin.ts
@@ -1,0 +1,13 @@
+import { SlatePlugin } from 'types';
+import { onKeyDownMark } from '../onKeyDownMark';
+import { deserializeSubscript } from './deserializeSubscript';
+import { renderLeafSubscript } from './renderLeafSubscript';
+import { MARK_SUBSCRIPT, SubscriptPluginOptions } from './types';
+
+export const SubscriptPlugin = ({
+  hotkey = 'mod+,',
+}: SubscriptPluginOptions = {}): SlatePlugin => ({
+  renderLeaf: renderLeafSubscript(),
+  onKeyDown: onKeyDownMark({ mark: MARK_SUBSCRIPT, hotkey }),
+  deserialize: deserializeSubscript(),
+});

--- a/packages/slate-plugins/src/marks/subscript/deserializeSubscript.ts
+++ b/packages/slate-plugins/src/marks/subscript/deserializeSubscript.ts
@@ -1,0 +1,10 @@
+import { DeserializeHtml } from 'deserializers/types';
+import { MARK_SUBSCRIPT } from './types';
+
+const leaf = { [MARK_SUBSCRIPT]: true };
+
+export const deserializeSubscript = (): DeserializeHtml => ({
+  leaf: {
+    SUB: () => leaf,
+  },
+});

--- a/packages/slate-plugins/src/marks/subscript/index.ts
+++ b/packages/slate-plugins/src/marks/subscript/index.ts
@@ -1,0 +1,3 @@
+export * from './SubscriptPlugin';
+export * from './renderLeafSubscript';
+export * from './types';

--- a/packages/slate-plugins/src/marks/subscript/renderLeafSubscript.tsx
+++ b/packages/slate-plugins/src/marks/subscript/renderLeafSubscript.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { RenderLeafProps } from 'slate-react';
+import { MARK_SUBSCRIPT } from './types';
+
+export const renderLeafSubscript = () => ({
+  children,
+  leaf,
+}: RenderLeafProps) => {
+  if (leaf[MARK_SUBSCRIPT]) return <sub>{children}</sub>;
+
+  return children;
+};

--- a/packages/slate-plugins/src/marks/subscript/types.ts
+++ b/packages/slate-plugins/src/marks/subscript/types.ts
@@ -1,0 +1,5 @@
+import { MarkPluginOptions } from '../types';
+
+export const MARK_SUBSCRIPT = 'SUBSCRIPT';
+
+export interface SubscriptPluginOptions extends MarkPluginOptions {}

--- a/packages/slate-plugins/src/marks/superscript/SuperscriptPlugin.ts
+++ b/packages/slate-plugins/src/marks/superscript/SuperscriptPlugin.ts
@@ -1,0 +1,13 @@
+import { SlatePlugin } from 'types';
+import { onKeyDownMark } from '../onKeyDownMark';
+import { deserializeSuperscript } from './deserializeSuperscript';
+import { renderLeafSuperscript } from './renderLeafSuperscript';
+import { MARK_SUPERSCRIPT, SuperscriptPluginOptions } from './types';
+
+export const SuperscriptPlugin = ({
+  hotkey = 'mod+.',
+}: SuperscriptPluginOptions = {}): SlatePlugin => ({
+  renderLeaf: renderLeafSuperscript(),
+  onKeyDown: onKeyDownMark({ mark: MARK_SUPERSCRIPT, hotkey }),
+  deserialize: deserializeSuperscript(),
+});

--- a/packages/slate-plugins/src/marks/superscript/SuperscriptPlugin.ts
+++ b/packages/slate-plugins/src/marks/superscript/SuperscriptPlugin.ts
@@ -1,5 +1,6 @@
 import { SlatePlugin } from 'types';
 import { onKeyDownMark } from '../onKeyDownMark';
+import { MARK_SUBSCRIPT } from '../subscript/types';
 import { deserializeSuperscript } from './deserializeSuperscript';
 import { renderLeafSuperscript } from './renderLeafSuperscript';
 import { MARK_SUPERSCRIPT, SuperscriptPluginOptions } from './types';
@@ -8,6 +9,10 @@ export const SuperscriptPlugin = ({
   hotkey = 'mod+.',
 }: SuperscriptPluginOptions = {}): SlatePlugin => ({
   renderLeaf: renderLeafSuperscript(),
-  onKeyDown: onKeyDownMark({ mark: MARK_SUPERSCRIPT, hotkey }),
+  onKeyDown: onKeyDownMark({
+    mark: MARK_SUPERSCRIPT,
+    clear: MARK_SUBSCRIPT,
+    hotkey,
+  }),
   deserialize: deserializeSuperscript(),
 });

--- a/packages/slate-plugins/src/marks/superscript/deserializeSuperscript.ts
+++ b/packages/slate-plugins/src/marks/superscript/deserializeSuperscript.ts
@@ -1,0 +1,10 @@
+import { DeserializeHtml } from 'deserializers/types';
+import { MARK_SUPERSCRIPT } from './types';
+
+const leaf = { [MARK_SUPERSCRIPT]: true };
+
+export const deserializeSuperscript = (): DeserializeHtml => ({
+  leaf: {
+    SUP: () => leaf,
+  },
+});

--- a/packages/slate-plugins/src/marks/superscript/index.ts
+++ b/packages/slate-plugins/src/marks/superscript/index.ts
@@ -1,0 +1,3 @@
+export * from './SuperscriptPlugin';
+export * from './renderLeafSuperscript';
+export * from './types';

--- a/packages/slate-plugins/src/marks/superscript/renderLeafSuperscript.tsx
+++ b/packages/slate-plugins/src/marks/superscript/renderLeafSuperscript.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { RenderLeafProps } from 'slate-react';
+import { MARK_SUPERSCRIPT } from './types';
+
+export const renderLeafSuperscript = () => ({
+  children,
+  leaf,
+}: RenderLeafProps) => {
+  if (leaf[MARK_SUPERSCRIPT]) return <sup>{children}</sup>;
+
+  return children;
+};

--- a/packages/slate-plugins/src/marks/superscript/types.ts
+++ b/packages/slate-plugins/src/marks/superscript/types.ts
@@ -1,0 +1,5 @@
+import { MarkPluginOptions } from '../types';
+
+export const MARK_SUPERSCRIPT = 'SUPERSCRIPT';
+
+export interface SuperscriptPluginOptions extends MarkPluginOptions {}

--- a/packages/slate-plugins/src/marks/transforms/clearMark.ts
+++ b/packages/slate-plugins/src/marks/transforms/clearMark.ts
@@ -1,0 +1,5 @@
+import { Editor } from 'slate';
+
+export const clearMark = (editor: Editor, format: string) => {
+  Editor.removeMark(editor, format);
+};

--- a/packages/slate-plugins/src/marks/transforms/index.ts
+++ b/packages/slate-plugins/src/marks/transforms/index.ts
@@ -1,1 +1,2 @@
 export * from './toggleMark';
+export * from './clearMark';

--- a/packages/slate-plugins/src/marks/types.ts
+++ b/packages/slate-plugins/src/marks/types.ts
@@ -4,5 +4,6 @@ export interface MarkPluginOptions {
 
 export interface OnKeyDownMarkOptions {
   mark: string;
+  clear?: string;
   hotkey: string;
 }

--- a/stories/plugins/marks.stories.tsx
+++ b/stories/plugins/marks.stories.tsx
@@ -6,6 +6,7 @@ import {
   FormatStrikethrough,
   FormatUnderlined,
   ArrowUpward,
+  ArrowDownward,
 } from '@material-ui/icons';
 import { boolean } from '@storybook/addon-knobs';
 import { createEditor } from 'slate';
@@ -21,9 +22,11 @@ import {
   MARK_CODE,
   MARK_ITALIC,
   MARK_STRIKETHROUGH,
+  MARK_SUBSCRIPT,
   MARK_SUPERSCRIPT,
   MARK_UNDERLINE,
   StrikethroughPlugin,
+  SubscriptPlugin,
   SuperscriptPlugin,
   ToolbarMark,
   UnderlinePlugin,
@@ -37,6 +40,7 @@ export default {
     ItalicPlugin,
     UnderlinePlugin,
     StrikethroughPlugin,
+    SubscriptPlugin,
     SuperscriptPlugin,
     InlineCodePlugin,
     MarkButton: ToolbarMark,
@@ -49,6 +53,7 @@ export const MarkPlugins = () => {
   if (boolean('ItalicPlugin', true)) plugins.push(ItalicPlugin());
   if (boolean('UnderlinePlugin', true)) plugins.push(UnderlinePlugin());
   if (boolean('StrikethroughPlugin', true)) plugins.push(StrikethroughPlugin());
+  if (boolean('SubscriptPlugin', true)) plugins.push(SubscriptPlugin());
   if (boolean('SuperscriptPlugin', true)) plugins.push(SuperscriptPlugin());
   if (boolean('InlineCodePlugin', true)) plugins.push(InlineCodePlugin());
 
@@ -72,6 +77,7 @@ export const MarkPlugins = () => {
             icon={<FormatStrikethrough />}
           />
           <ToolbarMark format={MARK_SUPERSCRIPT} icon={<ArrowUpward />} />
+          <ToolbarMark format={MARK_SUBSCRIPT} icon={<ArrowDownward />} />
           <ToolbarMark format={MARK_CODE} icon={<Code />} />
         </HeadingToolbar>
         <EditablePlugins

--- a/stories/plugins/marks.stories.tsx
+++ b/stories/plugins/marks.stories.tsx
@@ -5,6 +5,7 @@ import {
   FormatItalic,
   FormatStrikethrough,
   FormatUnderlined,
+  ArrowUpward,
 } from '@material-ui/icons';
 import { boolean } from '@storybook/addon-knobs';
 import { createEditor } from 'slate';
@@ -20,8 +21,10 @@ import {
   MARK_CODE,
   MARK_ITALIC,
   MARK_STRIKETHROUGH,
+  MARK_SUPERSCRIPT,
   MARK_UNDERLINE,
   StrikethroughPlugin,
+  SuperscriptPlugin,
   ToolbarMark,
   UnderlinePlugin,
 } from '../../packages/slate-plugins/src';
@@ -34,6 +37,7 @@ export default {
     ItalicPlugin,
     UnderlinePlugin,
     StrikethroughPlugin,
+    SuperscriptPlugin,
     InlineCodePlugin,
     MarkButton: ToolbarMark,
   },
@@ -45,6 +49,7 @@ export const MarkPlugins = () => {
   if (boolean('ItalicPlugin', true)) plugins.push(ItalicPlugin());
   if (boolean('UnderlinePlugin', true)) plugins.push(UnderlinePlugin());
   if (boolean('StrikethroughPlugin', true)) plugins.push(StrikethroughPlugin());
+  if (boolean('SuperscriptPlugin', true)) plugins.push(SuperscriptPlugin());
   if (boolean('InlineCodePlugin', true)) plugins.push(InlineCodePlugin());
 
   const createReactEditor = () => () => {
@@ -66,6 +71,7 @@ export const MarkPlugins = () => {
             format={MARK_STRIKETHROUGH}
             icon={<FormatStrikethrough />}
           />
+          <ToolbarMark format={MARK_SUPERSCRIPT} icon={<ArrowUpward />} />
           <ToolbarMark format={MARK_CODE} icon={<Code />} />
         </HeadingToolbar>
         <EditablePlugins

--- a/stories/plugins/playground.stories.tsx
+++ b/stories/plugins/playground.stories.tsx
@@ -1,5 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import {
+  ArrowUpward,
+  ArrowDownward,
   Code,
   FormatBold,
   FormatItalic,
@@ -40,6 +42,8 @@ import {
   MARK_CODE,
   MARK_ITALIC,
   MARK_STRIKETHROUGH,
+  MARK_SUBSCRIPT,
+  MARK_SUPERSCRIPT,
   MARK_UNDERLINE,
   MentionPlugin,
   MentionSelect,
@@ -48,6 +52,8 @@ import {
   ParagraphPlugin,
   SearchHighlightPlugin,
   SoftBreakPlugin,
+  SubscriptPlugin,
+  SuperscriptPlugin,
   TablePlugin,
   ToolbarBlock,
   ToolbarImage,
@@ -115,6 +121,8 @@ export const Plugins = () => {
   if (boolean('UnderlinePlugin', true)) plugins.push(UnderlinePlugin());
   if (boolean('VideoPlugin', true)) plugins.push(VideoPlugin());
   if (boolean('SoftBreakPlugin', true)) plugins.push(SoftBreakPlugin());
+  if (boolean('SubscriptPlugin', true)) plugins.push(SubscriptPlugin());
+  if (boolean('SuperscriptPlugin', true)) plugins.push(SuperscriptPlugin());
 
   const createReactEditor = () => () => {
     const decorate: any = [];
@@ -197,6 +205,8 @@ export const Plugins = () => {
             format={MARK_STRIKETHROUGH}
             icon={<FormatStrikethrough />}
           />
+          <ToolbarMark format={MARK_SUPERSCRIPT} icon={<ArrowUpward />} />
+          <ToolbarMark format={MARK_SUBSCRIPT} icon={<ArrowDownward />} />
           <ToolbarMark format={MARK_CODE} icon={<Code />} />
           <ToolbarList
             format={ListType.UL_LIST}

--- a/stories/plugins/playground.stories.tsx
+++ b/stories/plugins/playground.stories.tsx
@@ -205,8 +205,16 @@ export const Plugins = () => {
             format={MARK_STRIKETHROUGH}
             icon={<FormatStrikethrough />}
           />
-          <ToolbarMark format={MARK_SUPERSCRIPT} icon={<ArrowUpward />} />
-          <ToolbarMark format={MARK_SUBSCRIPT} icon={<ArrowDownward />} />
+          <ToolbarMark
+            format={MARK_SUPERSCRIPT}
+            clear={MARK_SUBSCRIPT}
+            icon={<ArrowUpward />}
+          />
+          <ToolbarMark
+            format={MARK_SUBSCRIPT}
+            clear={MARK_SUPERSCRIPT}
+            icon={<ArrowDownward />}
+          />
           <ToolbarMark format={MARK_CODE} icon={<Code />} />
           <ToolbarList
             format={ListType.UL_LIST}


### PR DESCRIPTION
Hello,

I am currently working on a Rich Text Editor based on this repository. One of the requirements I have is to also include **superscript** and **subscript**. I have decided to publish it here as separate plugins.

I have used standard HTML `<sub>` and `<sup>` tags without any additional styling so anyone can style them as pleased.

The only problem I have run into is that the material-ui icon set does not include superscript and subscript icons. I have decided to use arrow up and arrow down for these. If anyone has any better idea I am open :-)