### PR TITLE
Add types in options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,27 @@ This is a list of changes to Slate with each new release. Until 1.0.0 is release
 
 ###### BREAKING
 
-- Refactor:
-    - `getElement` to `getElementComponent`
-    - `getRenderElements`
+- refactor `getElement` to `getElementComponent`
+- refactor elements types to reflect the html tags. 
+Also avoiding `-` as it's not valid in GraphQL enums. 
+If you already saved elements in your database, you will need to override the types with the previous ones or migrate.
+    - `action-item` -> `action_item`
+    - `block-quote` -> `blockquote`
+    - `heading-one` -> `h1` (until `h6`)
+    - `link` -> `a`
+    - `numbered-list` -> `ol`
+    - `bulleted-list` -> `ul`
+    - `list-item` -> `li`
+    - `paragraph` -> `p`
+    - `table-row` -> `tr`
+    - `table-cell` -> `td`
+    
 
 ###### NEW
 
 - Ordered lists supported in `withShortcuts` (Markdown Shortcuts) by typing `1.`.
-- Option `type` to all elements. Not yet for the marks.
+- Option type to all elements. Not yet for the marks.
+- `getRenderElements`
 
 ### `0.57.15` — April 29, 2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ This is a list of changes to Slate with each new release. Until 1.0.0 is release
 
 ---
 
+### `0.57.15` — April 28, 2020
+
+###### BREAKING
+
+- Refactor:
+    - `getElement` to `getElementComponent`
+    - `getRenderElements`
+
+###### NEW
+
+- Ordered lists supported in `withShortcuts` (Markdown Shortcuts) by typing `1.`.
+- Option `type` to all elements. Not yet for the marks.
+
 ### `0.57.14` — April 26, 2020
 
 ###### NEW

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ This is a list of changes to Slate with each new release. Until 1.0.0 is release
 - refactor `getElement` to `getElementComponent`
 - refactor elements types to reflect the html tags. 
 Also avoiding `-` as it's not valid in GraphQL enums. 
-If you already saved elements in your database, you will need to override the types with the previous ones or migrate.
     - `action-item` -> `action_item`
     - `block-quote` -> `blockquote`
     - `heading-one` -> `h1` (until `h6`)
@@ -22,7 +21,34 @@ If you already saved elements in your database, you will need to override the ty
     - `paragraph` -> `p`
     - `table-row` -> `tr`
     - `table-cell` -> `td`
-    
+If you already saved elements in your database, you will need to migrate or override the types with the previous ones:
+
+```js
+// you can add nodeTypes to any element plugin
+export const nodeTypes = {
+  typeP: PARAGRAPH,
+  typeMention: MENTION,
+  typeBlockquote: BLOCKQUOTE,
+  typeCode: CODE,
+  typeLink: LINK,
+  typeImg: IMAGE,
+  typeVideo: VIDEO,
+  typeActionItem: ACTION_ITEM,
+  typeTable: TableType.TABLE,
+  typeTr: TableType.ROW,
+  typeTd: TableType.CELL,
+  typeUl: ListType.UL,
+  typeOl: ListType.OL,
+  typeLi: ListType.LI,
+  typeH1: HeadingType.H1,
+  typeH2: HeadingType.H2,
+  typeH3: HeadingType.H3,
+  typeH4: HeadingType.H4,
+  typeH5: HeadingType.H5,
+  typeH6: HeadingType.H6,
+  typeEditableVoid: EDITABLE_VOID,
+};
+```
 
 ###### NEW
 

--- a/packages/slate-plugins/src/common/types.ts
+++ b/packages/slate-plugins/src/common/types.ts
@@ -2,10 +2,15 @@ export interface ToolbarElementProps {
   icon: any;
   height?: string;
   reversed?: boolean;
+  type?: string;
   [key: string]: any;
 }
 
-export interface ToolbarFormatProps extends ToolbarElementProps {
-  format: string;
+export interface ToolbarBlockProps extends ToolbarElementProps {
+  type: string;
+  onMouseDown?: (event: any) => void;
+}
+
+export interface ToolbarCustomProps extends ToolbarElementProps {
   onMouseDown?: (event: any) => void;
 }

--- a/packages/slate-plugins/src/elements/action-item/components/ActionItemElement.tsx
+++ b/packages/slate-plugins/src/elements/action-item/components/ActionItemElement.tsx
@@ -7,7 +7,6 @@ import {
   useReadOnly,
 } from 'slate-react';
 import styled from 'styled-components';
-import { ACTION_ITEM } from '../types';
 
 const Wrapper = styled.div`
   display: flex;
@@ -51,7 +50,7 @@ export const ActionItemElement = ({
   const { checked } = element;
 
   return (
-    <Wrapper {...attributes} data-slate-type={ACTION_ITEM}>
+    <Wrapper {...attributes}>
       <CheckboxWrapper contentEditable={false}>
         <Checkbox
           type="checkbox"

--- a/packages/slate-plugins/src/elements/action-item/renderElementActionItem.ts
+++ b/packages/slate-plugins/src/elements/action-item/renderElementActionItem.ts
@@ -1,8 +1,13 @@
+import { RenderElementOptions } from 'elements/types';
 import { getRenderElement } from '../utils';
 import { ActionItemElement } from './components';
 import { ACTION_ITEM } from './types';
 
-export const renderElementActionItem = getRenderElement({
-  type: ACTION_ITEM,
-  component: ActionItemElement,
-});
+export const renderElementActionItem = ({
+  typeActionItem = ACTION_ITEM,
+  component = ActionItemElement,
+}: RenderElementOptions = {}) =>
+  getRenderElement({
+    type: typeActionItem,
+    component,
+  });

--- a/packages/slate-plugins/src/elements/action-item/types.ts
+++ b/packages/slate-plugins/src/elements/action-item/types.ts
@@ -1,1 +1,1 @@
-export const ACTION_ITEM = 'action-item';
+export const ACTION_ITEM = 'action_item';

--- a/packages/slate-plugins/src/elements/blockquote/BlockquotePlugin.ts
+++ b/packages/slate-plugins/src/elements/blockquote/BlockquotePlugin.ts
@@ -4,8 +4,8 @@ import { deserializeBlockquote } from './deserializeBlockquote';
 import { renderElementBlockquote } from './renderElementBlockquote';
 
 export const BlockquotePlugin = (
-  options?: RenderElementOptions
+  options?: RenderElementOptions & { typeBlockquote?: string }
 ): SlatePlugin => ({
   renderElement: renderElementBlockquote(options),
-  deserialize: deserializeBlockquote(),
+  deserialize: deserializeBlockquote(options),
 });

--- a/packages/slate-plugins/src/elements/blockquote/components/BlockquoteElement.tsx
+++ b/packages/slate-plugins/src/elements/blockquote/components/BlockquoteElement.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { RenderElementProps } from 'slate-react';
 import styled from 'styled-components';
-import { BLOCKQUOTE } from '../types';
 
 const StyledBlockquoteElement = styled.blockquote`
   border-left: 2px solid #ddd;
@@ -15,7 +14,5 @@ export const BlockquoteElement = ({
   attributes,
   children,
 }: RenderElementProps) => (
-  <StyledBlockquoteElement {...attributes} data-slate-type={BLOCKQUOTE}>
-    {children}
-  </StyledBlockquoteElement>
+  <StyledBlockquoteElement {...attributes}>{children}</StyledBlockquoteElement>
 );

--- a/packages/slate-plugins/src/elements/blockquote/deserializeBlockquote.ts
+++ b/packages/slate-plugins/src/elements/blockquote/deserializeBlockquote.ts
@@ -1,8 +1,10 @@
 import { DeserializeHtml } from 'deserializers/types';
 import { BLOCKQUOTE } from './types';
 
-export const deserializeBlockquote = (): DeserializeHtml => ({
+export const deserializeBlockquote = ({
+  typeBlockquote = BLOCKQUOTE,
+} = {}): DeserializeHtml => ({
   element: {
-    BLOCKQUOTE: () => ({ type: BLOCKQUOTE }),
+    BLOCKQUOTE: () => ({ type: typeBlockquote }),
   },
 });

--- a/packages/slate-plugins/src/elements/blockquote/renderElementBlockquote.ts
+++ b/packages/slate-plugins/src/elements/blockquote/renderElementBlockquote.ts
@@ -1,8 +1,13 @@
+import { RenderElementOptions } from 'elements/types';
 import { getRenderElement } from '../utils';
 import { BlockquoteElement } from './components';
 import { BLOCKQUOTE } from './types';
 
-export const renderElementBlockquote = getRenderElement({
-  type: BLOCKQUOTE,
-  component: BlockquoteElement,
-});
+export const renderElementBlockquote = ({
+  typeBlockquote = BLOCKQUOTE,
+  component = BlockquoteElement,
+}: RenderElementOptions = {}) =>
+  getRenderElement({
+    type: typeBlockquote,
+    component,
+  });

--- a/packages/slate-plugins/src/elements/blockquote/types.ts
+++ b/packages/slate-plugins/src/elements/blockquote/types.ts
@@ -1,1 +1,1 @@
-export const BLOCKQUOTE = 'block-quote';
+export const BLOCKQUOTE = 'blockquote';

--- a/packages/slate-plugins/src/elements/code/CodePlugin.ts
+++ b/packages/slate-plugins/src/elements/code/CodePlugin.ts
@@ -3,7 +3,9 @@ import { RenderElementOptions } from '../types';
 import { deserializeCode } from './deserializeCode';
 import { renderElementCode } from './renderElementCode';
 
-export const CodePlugin = (options?: RenderElementOptions): SlatePlugin => ({
+export const CodePlugin = (
+  options?: RenderElementOptions & { typeCode?: string }
+): SlatePlugin => ({
   renderElement: renderElementCode(options),
-  deserialize: deserializeCode(),
+  deserialize: deserializeCode(options),
 });

--- a/packages/slate-plugins/src/elements/code/components/CodeElement.tsx
+++ b/packages/slate-plugins/src/elements/code/components/CodeElement.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { RenderElementProps } from 'slate-react';
 import styled from 'styled-components';
-import { CODE } from '../types';
 
 const Pre = styled.pre`
   padding: 10px;
@@ -11,8 +10,6 @@ const Pre = styled.pre`
 
 export const CodeElement = ({ attributes, children }: RenderElementProps) => (
   <Pre>
-    <code {...attributes} data-slate-type={CODE}>
-      {children}
-    </code>
+    <code {...attributes}>{children}</code>
   </Pre>
 );

--- a/packages/slate-plugins/src/elements/code/components/ToolbarCode.tsx
+++ b/packages/slate-plugins/src/elements/code/components/ToolbarCode.tsx
@@ -6,17 +6,20 @@ import { isBlockActive } from '../../queries';
 import { toggleCode } from '../transforms';
 import { CODE } from '../types';
 
-export const ToolbarCode = (props: ToolbarElementProps) => {
+export const ToolbarCode = ({
+  typeCode = CODE,
+  ...props
+}: ToolbarElementProps) => {
   const editor = useSlate();
 
   return (
     <ToolbarButton
       {...props}
-      active={isBlockActive(editor, CODE)}
+      active={isBlockActive(editor, typeCode)}
       onMouseDown={(event: Event) => {
         event.preventDefault();
 
-        toggleCode(editor);
+        toggleCode(editor, { typeCode });
       }}
     />
   );

--- a/packages/slate-plugins/src/elements/code/deserializeCode.ts
+++ b/packages/slate-plugins/src/elements/code/deserializeCode.ts
@@ -1,8 +1,8 @@
 import { DeserializeHtml } from 'deserializers/types';
 import { CODE } from './types';
 
-export const deserializeCode = (): DeserializeHtml => ({
+export const deserializeCode = ({ typeCode = CODE } = {}): DeserializeHtml => ({
   element: {
-    PRE: () => ({ type: CODE }),
+    PRE: () => ({ type: typeCode }),
   },
 });

--- a/packages/slate-plugins/src/elements/code/renderElementCode.tsx
+++ b/packages/slate-plugins/src/elements/code/renderElementCode.tsx
@@ -1,8 +1,13 @@
+import { RenderElementOptions } from 'elements/types';
 import { getRenderElement } from '../utils';
 import { CodeElement } from './components';
 import { CODE } from './types';
 
-export const renderElementCode = getRenderElement({
-  type: CODE,
-  component: CodeElement,
-});
+export const renderElementCode = ({
+  typeCode = CODE,
+  component = CodeElement,
+}: RenderElementOptions = {}) =>
+  getRenderElement({
+    type: typeCode,
+    component,
+  });

--- a/packages/slate-plugins/src/elements/code/transforms/toggleCode.ts
+++ b/packages/slate-plugins/src/elements/code/transforms/toggleCode.ts
@@ -2,14 +2,14 @@ import { Editor, Transforms } from 'slate';
 import { isBlockActive } from '../../queries';
 import { CODE } from '../types';
 
-export const toggleCode = (editor: Editor) => {
-  if (isBlockActive(editor, CODE)) {
+export const toggleCode = (editor: Editor, { typeCode = CODE } = {}) => {
+  if (isBlockActive(editor, typeCode)) {
     Transforms.unwrapNodes(editor, {
-      match: (node) => node.type === CODE,
+      match: (node) => node.type === typeCode,
     });
   } else {
     Transforms.wrapNodes(editor, {
-      type: CODE,
+      type: typeCode,
       children: [],
     });
   }

--- a/packages/slate-plugins/src/elements/components/ToolbarBlock.tsx
+++ b/packages/slate-plugins/src/elements/components/ToolbarBlock.tsx
@@ -1,27 +1,27 @@
 import React from 'react';
 import { ToolbarButton } from 'common';
-import { ToolbarFormatProps } from 'common/types';
+import { ToolbarBlockProps } from 'common/types';
 import { useSlate } from 'slate-react';
 import { isBlockActive } from '../queries';
 
 export const ToolbarBlock = ({
-  format,
+  type,
   onMouseDown,
   ...props
-}: ToolbarFormatProps) => {
+}: ToolbarBlockProps) => {
   const editor = useSlate();
 
   if (!onMouseDown) {
     onMouseDown = (event: Event) => {
       event.preventDefault();
-      editor.toggleBlock(format);
+      editor.toggleBlock(type);
     };
   }
 
   return (
     <ToolbarButton
       {...props}
-      active={isBlockActive(editor, format)}
+      active={isBlockActive(editor, type)}
       onMouseDown={onMouseDown}
     />
   );

--- a/packages/slate-plugins/src/elements/heading/HeadingPlugin.ts
+++ b/packages/slate-plugins/src/elements/heading/HeadingPlugin.ts
@@ -5,5 +5,5 @@ import { HeadingPluginOptions } from './types';
 
 export const HeadingPlugin = (options?: HeadingPluginOptions): SlatePlugin => ({
   renderElement: renderElementHeading(options),
-  deserialize: deserializeHeading({ levels: options?.levels }),
+  deserialize: deserializeHeading(options),
 });

--- a/packages/slate-plugins/src/elements/heading/deserializeHeading.ts
+++ b/packages/slate-plugins/src/elements/heading/deserializeHeading.ts
@@ -3,16 +3,22 @@ import { DeserializeHeadingOptions, HeadingType } from './types';
 
 export const deserializeHeading = ({
   levels = 6,
-}: DeserializeHeadingOptions): DeserializeHtml => {
+  typeH1 = HeadingType.H1,
+  typeH2 = HeadingType.H2,
+  typeH3 = HeadingType.H3,
+  typeH4 = HeadingType.H4,
+  typeH5 = HeadingType.H5,
+  typeH6 = HeadingType.H6,
+}: DeserializeHeadingOptions = {}): DeserializeHtml => {
   const headingTags: any = {
-    H1: () => ({ type: HeadingType.H1 }),
+    H1: () => ({ type: typeH1 }),
   };
 
-  if (levels >= 2) headingTags.H2 = () => ({ type: HeadingType.H2 });
-  if (levels >= 3) headingTags.H3 = () => ({ type: HeadingType.H3 });
-  if (levels >= 4) headingTags.H4 = () => ({ type: HeadingType.H4 });
-  if (levels >= 5) headingTags.H5 = () => ({ type: HeadingType.H5 });
-  if (levels >= 6) headingTags.H6 = () => ({ type: HeadingType.H6 });
+  if (levels >= 2) headingTags.H2 = () => ({ type: typeH2 });
+  if (levels >= 3) headingTags.H3 = () => ({ type: typeH3 });
+  if (levels >= 4) headingTags.H4 = () => ({ type: typeH4 });
+  if (levels >= 5) headingTags.H5 = () => ({ type: typeH5 });
+  if (levels >= 6) headingTags.H6 = () => ({ type: typeH6 });
 
   return {
     element: headingTags,

--- a/packages/slate-plugins/src/elements/heading/renderElementHeading.tsx
+++ b/packages/slate-plugins/src/elements/heading/renderElementHeading.tsx
@@ -37,9 +37,9 @@ const StyledH3 = styled(Heading)`
 
 export const renderElementHeading = ({
   levels = 6,
-  H1 = StyledH1,
-  H2 = StyledH2,
-  H3 = StyledH3,
+  H1 = getElementComponent(StyledH1),
+  H2 = getElementComponent(StyledH2),
+  H3 = getElementComponent(StyledH3),
   H4 = getElementComponent('h4'),
   H5 = getElementComponent('h5'),
   H6 = getElementComponent('h6'),

--- a/packages/slate-plugins/src/elements/heading/renderElementHeading.tsx
+++ b/packages/slate-plugins/src/elements/heading/renderElementHeading.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { RenderElementProps } from 'slate-react';
 import styled from 'styled-components';
-import { getElement } from '../utils';
+import { getElementComponent } from '../utils';
 import { HeadingType, RenderElementHeadingOptions } from './types';
 
 const Heading = styled.div`
@@ -40,18 +40,24 @@ export const renderElementHeading = ({
   H1 = StyledH1,
   H2 = StyledH2,
   H3 = StyledH3,
-  H4 = getElement('h4'),
-  H5 = getElement('h5'),
-  H6 = getElement('h6'),
+  H4 = getElementComponent('h4'),
+  H5 = getElementComponent('h5'),
+  H6 = getElementComponent('h6'),
+  typeH1 = HeadingType.H1,
+  typeH2 = HeadingType.H2,
+  typeH3 = HeadingType.H3,
+  typeH4 = HeadingType.H4,
+  typeH5 = HeadingType.H5,
+  typeH6 = HeadingType.H6,
 }: RenderElementHeadingOptions = {}) => (props: RenderElementProps) => {
   const {
     element: { type },
   } = props;
 
-  if (levels >= 1 && type === HeadingType.H1) return <H1 {...props} />;
-  if (levels >= 2 && type === HeadingType.H2) return <H2 {...props} />;
-  if (levels >= 3 && type === HeadingType.H3) return <H3 {...props} />;
-  if (levels >= 4 && type === HeadingType.H4) return <H4 {...props} />;
-  if (levels >= 5 && type === HeadingType.H5) return <H5 {...props} />;
-  if (levels >= 6 && type === HeadingType.H6) return <H6 {...props} />;
+  if (levels >= 1 && type === typeH1) return <H1 {...props} />;
+  if (levels >= 2 && type === typeH2) return <H2 {...props} />;
+  if (levels >= 3 && type === typeH3) return <H3 {...props} />;
+  if (levels >= 4 && type === typeH4) return <H4 {...props} />;
+  if (levels >= 5 && type === typeH5) return <H5 {...props} />;
+  if (levels >= 6 && type === typeH6) return <H6 {...props} />;
 };

--- a/packages/slate-plugins/src/elements/heading/types.ts
+++ b/packages/slate-plugins/src/elements/heading/types.ts
@@ -7,18 +7,26 @@ export enum HeadingType {
   H6 = 'heading-six',
 }
 
-export interface RenderElementHeadingOptions {
+export interface HeadingTypeOptions {
+  typeH1?: string;
+  typeH2?: string;
+  typeH3?: string;
+  typeH4?: string;
+  typeH5?: string;
+  typeH6?: string;
+}
+
+export interface DeserializeHeadingOptions extends HeadingTypeOptions {
   levels?: number;
+}
+
+export interface RenderElementHeadingOptions extends DeserializeHeadingOptions {
   H1?: any;
   H2?: any;
   H3?: any;
   H4?: any;
   H5?: any;
   H6?: any;
-}
-
-export interface DeserializeHeadingOptions {
-  levels?: number;
 }
 
 export interface HeadingPluginOptions extends RenderElementHeadingOptions {}

--- a/packages/slate-plugins/src/elements/heading/types.ts
+++ b/packages/slate-plugins/src/elements/heading/types.ts
@@ -1,10 +1,10 @@
 export enum HeadingType {
-  H1 = 'heading-one',
-  H2 = 'heading-two',
-  H3 = 'heading-three',
-  H4 = 'heading-four',
-  H5 = 'heading-five',
-  H6 = 'heading-six',
+  H1 = 'h1',
+  H2 = 'h2',
+  H3 = 'h3',
+  H4 = 'h4',
+  H5 = 'h5',
+  H6 = 'h6',
 }
 
 export interface HeadingTypeOptions {

--- a/packages/slate-plugins/src/elements/image/ImagePlugin.ts
+++ b/packages/slate-plugins/src/elements/image/ImagePlugin.ts
@@ -1,9 +1,11 @@
+import { renderElementImage } from 'elements/image/renderElementImage';
 import { SlatePlugin } from 'types';
 import { RenderElementOptions } from '../types';
 import { deserializeImage } from './deserializeImage';
-import { renderElementImage } from './renderElementImage';
 
-export const ImagePlugin = (options?: RenderElementOptions): SlatePlugin => ({
+export const ImagePlugin = (
+  options?: RenderElementOptions & { typeImg?: string }
+): SlatePlugin => ({
   renderElement: renderElementImage(options),
-  deserialize: deserializeImage(),
+  deserialize: deserializeImage(options),
 });

--- a/packages/slate-plugins/src/elements/image/components/ImageElement.tsx
+++ b/packages/slate-plugins/src/elements/image/components/ImageElement.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { RenderElementProps, useFocused, useSelected } from 'slate-react';
 import styled from 'styled-components';
-import { IMAGE } from '../types';
 
 const Image = styled.img<{ selected: boolean; focused: boolean }>`
   display: block;
@@ -21,7 +20,7 @@ export const ImageElement = ({
   const focused = useFocused();
 
   return (
-    <div {...attributes} data-slate-type={IMAGE}>
+    <div {...attributes}>
       <div contentEditable={false}>
         <Image src={element.url} alt="" selected={selected} focused={focused} />
       </div>

--- a/packages/slate-plugins/src/elements/image/components/ToolbarImage.tsx
+++ b/packages/slate-plugins/src/elements/image/components/ToolbarImage.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
 import { ToolbarButton } from 'common';
 import { ToolbarElementProps } from 'common/types';
+import { IMAGE } from 'elements/image/types';
 import { useEditor } from 'slate-react';
 import { insertImage } from '../transforms';
 
-export const ToolbarImage = (props: ToolbarElementProps) => {
+export const ToolbarImage = ({
+  typeImg = IMAGE,
+  ...props
+}: ToolbarElementProps) => {
   const editor = useEditor();
 
   return (
@@ -15,7 +19,7 @@ export const ToolbarImage = (props: ToolbarElementProps) => {
 
         const url = window.prompt('Enter the URL of the image:');
         if (!url) return;
-        insertImage(editor, url);
+        insertImage(editor, url, { typeImg });
       }}
     />
   );

--- a/packages/slate-plugins/src/elements/image/deserializeImage.ts
+++ b/packages/slate-plugins/src/elements/image/deserializeImage.ts
@@ -1,10 +1,12 @@
 import { DeserializeHtml } from 'deserializers/types';
 import { IMAGE } from './types';
 
-export const deserializeImage = (): DeserializeHtml => ({
+export const deserializeImage = ({
+  typeImg = IMAGE,
+} = {}): DeserializeHtml => ({
   element: {
     IMG: (el) => ({
-      type: IMAGE,
+      type: typeImg,
       url: el.getAttribute('src'),
     }),
   },

--- a/packages/slate-plugins/src/elements/image/renderElementImage.ts
+++ b/packages/slate-plugins/src/elements/image/renderElementImage.ts
@@ -1,0 +1,13 @@
+import { RenderElementOptions } from 'elements/types';
+import { getRenderElement } from '../utils';
+import { ImageElement } from './components';
+import { IMAGE } from './types';
+
+export const renderElementImage = ({
+  typeImg = IMAGE,
+  component = ImageElement,
+}: RenderElementOptions = {}) =>
+  getRenderElement({
+    type: typeImg,
+    component,
+  });

--- a/packages/slate-plugins/src/elements/image/renderElementImage.tsx
+++ b/packages/slate-plugins/src/elements/image/renderElementImage.tsx
@@ -1,8 +1,0 @@
-import { getRenderElement } from '../utils';
-import { ImageElement } from './components';
-import { IMAGE } from './types';
-
-export const renderElementImage = getRenderElement({
-  type: IMAGE,
-  component: ImageElement,
-});

--- a/packages/slate-plugins/src/elements/image/transforms/insertImage.ts
+++ b/packages/slate-plugins/src/elements/image/transforms/insertImage.ts
@@ -1,8 +1,12 @@
 import { Editor, Transforms } from 'slate';
 import { IMAGE } from '../types';
 
-export const insertImage = (editor: Editor, url: string | ArrayBuffer) => {
+export const insertImage = (
+  editor: Editor,
+  url: string | ArrayBuffer,
+  { typeImg = IMAGE } = {}
+) => {
   const text = { text: '' };
-  const image = { type: IMAGE, url, children: [text] };
+  const image = { type: typeImg, url, children: [text] };
   Transforms.insertNodes(editor, image);
 };

--- a/packages/slate-plugins/src/elements/image/types.ts
+++ b/packages/slate-plugins/src/elements/image/types.ts
@@ -1,1 +1,1 @@
-export const IMAGE = 'image';
+export const IMAGE = 'img';

--- a/packages/slate-plugins/src/elements/image/withImage.ts
+++ b/packages/slate-plugins/src/elements/image/withImage.ts
@@ -4,8 +4,10 @@ import { isImageUrl } from './utils/isImageUrl';
 import { insertImage } from './transforms';
 import { IMAGE } from './types';
 
-export const withImage = <T extends ReactEditor>(editor: T) => {
-  editor = withVoid([IMAGE])(editor);
+export const withImage = ({ typeImg = IMAGE } = {}) => <T extends ReactEditor>(
+  editor: T
+) => {
+  editor = withVoid([typeImg])(editor);
 
   const { insertData } = editor;
 

--- a/packages/slate-plugins/src/elements/link/LinkPlugin.ts
+++ b/packages/slate-plugins/src/elements/link/LinkPlugin.ts
@@ -3,7 +3,9 @@ import { RenderElementOptions } from '../types';
 import { deserializeLink } from './deserializeLink';
 import { renderElementLink } from './renderElementLink';
 
-export const LinkPlugin = (options?: RenderElementOptions): SlatePlugin => ({
+export const LinkPlugin = (
+  options?: RenderElementOptions & { typeLink?: string }
+): SlatePlugin => ({
   renderElement: renderElementLink(options),
-  deserialize: deserializeLink(),
+  deserialize: deserializeLink(options),
 });

--- a/packages/slate-plugins/src/elements/link/components/LinkElement.tsx
+++ b/packages/slate-plugins/src/elements/link/components/LinkElement.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import { RenderElementProps } from 'slate-react';
-import { LINK } from '../types';
 
 export const LinkElement = ({
   attributes,
   children,
   element,
 }: RenderElementProps) => (
-  <a {...attributes} data-slate-type={LINK} href={element.url}>
+  <a {...attributes} href={element.url}>
     {children}
   </a>
 );

--- a/packages/slate-plugins/src/elements/link/components/ToolbarLink.tsx
+++ b/packages/slate-plugins/src/elements/link/components/ToolbarLink.tsx
@@ -1,23 +1,23 @@
 import React from 'react';
 import { ToolbarButton } from 'common';
-import { ToolbarElementProps } from 'common/types';
+import { ToolbarCustomProps } from 'common/types';
 import { useSlate } from 'slate-react';
 import { isLinkActive } from '../queries';
 import { insertLink } from '../transforms';
 
-export const ToolbarLink = (props: ToolbarElementProps) => {
+export const ToolbarLink = ({ typeLink, ...props }: ToolbarCustomProps) => {
   const editor = useSlate();
 
   return (
     <ToolbarButton
       {...props}
-      active={isLinkActive(editor)}
+      active={isLinkActive(editor, { typeLink })}
       onMouseDown={(event: Event) => {
         event.preventDefault();
 
         const url = window.prompt('Enter the URL of the link:');
         if (!url) return;
-        insertLink(editor, url);
+        insertLink(editor, url, { typeLink });
       }}
     />
   );

--- a/packages/slate-plugins/src/elements/link/deserializeLink.ts
+++ b/packages/slate-plugins/src/elements/link/deserializeLink.ts
@@ -1,8 +1,8 @@
 import { DeserializeHtml } from 'deserializers/types';
 import { LINK } from './types';
 
-export const deserializeLink = (): DeserializeHtml => ({
+export const deserializeLink = ({ typeLink = LINK } = {}): DeserializeHtml => ({
   element: {
-    A: (el) => ({ type: LINK, url: el.getAttribute('href') }),
+    A: (el) => ({ type: typeLink, url: el.getAttribute('href') }),
   },
 });

--- a/packages/slate-plugins/src/elements/link/queries/isLinkActive.ts
+++ b/packages/slate-plugins/src/elements/link/queries/isLinkActive.ts
@@ -1,9 +1,9 @@
 import { Editor } from 'slate';
 import { LINK } from '../types';
 
-export const isLinkActive = (editor: Editor) => {
+export const isLinkActive = (editor: Editor, { typeLink = LINK } = {}) => {
   const [link] = Editor.nodes(editor, {
-    match: (n) => n.type === LINK,
+    match: (n) => n.type === typeLink,
   });
 
   return !!link;

--- a/packages/slate-plugins/src/elements/link/renderElementLink.ts
+++ b/packages/slate-plugins/src/elements/link/renderElementLink.ts
@@ -1,8 +1,13 @@
+import { RenderElementOptions } from 'elements/types';
 import { getRenderElement } from '../utils';
 import { LinkElement } from './components';
 import { LINK } from './types';
 
-export const renderElementLink = getRenderElement({
-  type: LINK,
-  component: LinkElement,
-});
+export const renderElementLink = ({
+  typeLink = LINK,
+  component = LinkElement,
+}: RenderElementOptions = {}) =>
+  getRenderElement({
+    type: typeLink,
+    component,
+  });

--- a/packages/slate-plugins/src/elements/link/transforms/insertLink.ts
+++ b/packages/slate-plugins/src/elements/link/transforms/insertLink.ts
@@ -1,8 +1,13 @@
+import { LINK } from 'elements/link/types';
 import { Editor } from 'slate';
 import { wrapLink } from './wrapLink';
 
-export const insertLink = (editor: Editor, url: string) => {
+export const insertLink = (
+  editor: Editor,
+  url: string,
+  { typeLink = LINK }
+) => {
   if (editor.selection) {
-    wrapLink(editor, url);
+    wrapLink(editor, url, { typeLink });
   }
 };

--- a/packages/slate-plugins/src/elements/link/transforms/unwrapLink.ts
+++ b/packages/slate-plugins/src/elements/link/transforms/unwrapLink.ts
@@ -1,6 +1,6 @@
 import { Editor, Transforms } from 'slate';
 import { LINK } from '../types';
 
-export const unwrapLink = (editor: Editor) => {
-  Transforms.unwrapNodes(editor, { match: (n) => n.type === LINK });
+export const unwrapLink = (editor: Editor, { typeLink = LINK } = {}) => {
+  Transforms.unwrapNodes(editor, { match: (n) => n.type === typeLink });
 };

--- a/packages/slate-plugins/src/elements/link/transforms/wrapLink.ts
+++ b/packages/slate-plugins/src/elements/link/transforms/wrapLink.ts
@@ -1,17 +1,21 @@
+import { isLinkActive } from 'elements/link/queries';
 import { Editor, Range, Transforms } from 'slate';
-import { isLinkActive } from '../queries/isLinkActive';
 import { LINK } from '../types';
 import { unwrapLink } from './unwrapLink';
 
-export const wrapLink = (editor: Editor, url: string) => {
+export const wrapLink = (
+  editor: Editor,
+  url: string,
+  { typeLink = LINK } = {}
+) => {
   if (isLinkActive(editor)) {
-    unwrapLink(editor);
+    unwrapLink(editor, { typeLink });
   }
 
   const { selection } = editor;
   const isCollapsed = selection && Range.isCollapsed(selection);
   const link = {
-    type: LINK,
+    type: typeLink,
     url,
     children: isCollapsed ? [{ text: url }] : [],
   };

--- a/packages/slate-plugins/src/elements/link/types.ts
+++ b/packages/slate-plugins/src/elements/link/types.ts
@@ -1,1 +1,1 @@
-export const LINK = 'link';
+export const LINK = 'a';

--- a/packages/slate-plugins/src/elements/link/withLink.ts
+++ b/packages/slate-plugins/src/elements/link/withLink.ts
@@ -4,8 +4,10 @@ import { ReactEditor } from 'slate-react';
 import { wrapLink } from './transforms';
 import { LINK } from './types';
 
-export const withLink = <T extends ReactEditor>(editor: T) => {
-  editor = withInline([LINK])(editor);
+export const withLink = ({ typeLink = LINK } = {}) => <T extends ReactEditor>(
+  editor: T
+) => {
+  editor = withInline([typeLink])(editor);
 
   const { insertData, insertText } = editor;
 

--- a/packages/slate-plugins/src/elements/list/ListPlugin.ts
+++ b/packages/slate-plugins/src/elements/list/ListPlugin.ts
@@ -8,6 +8,6 @@ export const ListPlugin = (
   options?: RenderElementListOptions
 ): SlatePlugin => ({
   renderElement: renderElementList(options),
-  deserialize: deserializeList(),
-  onKeyDown: onKeyDownList(),
+  deserialize: deserializeList(options),
+  onKeyDown: onKeyDownList(options),
 });

--- a/packages/slate-plugins/src/elements/list/components/ToolbarList.tsx
+++ b/packages/slate-plugins/src/elements/list/components/ToolbarList.tsx
@@ -7,7 +7,6 @@ import { toggleList } from '../transforms';
 
 export const ToolbarList = ({
   typeList = ListType.UL,
-  typeLi = ListType.LI,
   ...props
 }: ToolbarCustomProps) => {
   const editor = useSlate();
@@ -18,7 +17,7 @@ export const ToolbarList = ({
       type={typeList}
       onMouseDown={(event: Event) => {
         event.preventDefault();
-        toggleList(editor, { typeList, typeLi });
+        toggleList(editor, { ...props, typeList });
       }}
     />
   );

--- a/packages/slate-plugins/src/elements/list/components/ToolbarList.tsx
+++ b/packages/slate-plugins/src/elements/list/components/ToolbarList.tsx
@@ -1,19 +1,24 @@
 import React from 'react';
-import { ToolbarFormatProps } from 'common/types';
+import { ToolbarCustomProps } from 'common/types';
 import { ToolbarBlock } from 'elements/components';
+import { ListType } from 'elements/list/types';
 import { useSlate } from 'slate-react';
 import { toggleList } from '../transforms';
 
-export const ToolbarList = (props: ToolbarFormatProps) => {
+export const ToolbarList = ({
+  typeList = ListType.UL,
+  typeLi = ListType.LI,
+  ...props
+}: ToolbarCustomProps) => {
   const editor = useSlate();
-  const { format } = props;
 
   return (
     <ToolbarBlock
       {...props}
+      type={typeList}
       onMouseDown={(event: Event) => {
         event.preventDefault();
-        toggleList(editor, format);
+        toggleList(editor, { typeList, typeLi });
       }}
     />
   );

--- a/packages/slate-plugins/src/elements/list/deserializeList.ts
+++ b/packages/slate-plugins/src/elements/list/deserializeList.ts
@@ -1,10 +1,14 @@
 import { DeserializeHtml } from 'deserializers/types';
-import { ListType } from './types';
+import { ListType, ListTypeOptions } from './types';
 
-export const deserializeList = (): DeserializeHtml => ({
+export const deserializeList = ({
+  typeUl = ListType.UL,
+  typeOl = ListType.OL,
+  typeLi = ListType.LI,
+}: ListTypeOptions = {}): DeserializeHtml => ({
   element: {
-    UL: () => ({ type: ListType.UL_LIST }),
-    OL: () => ({ type: ListType.OL_LIST }),
-    LI: () => ({ type: ListType.LIST_ITEM }),
+    UL: () => ({ type: typeUl }),
+    OL: () => ({ type: typeOl }),
+    LI: () => ({ type: typeLi }),
   },
 });

--- a/packages/slate-plugins/src/elements/list/onKeyDownList.ts
+++ b/packages/slate-plugins/src/elements/list/onKeyDownList.ts
@@ -115,10 +115,10 @@ export const onKeyDownList = ({
   typeLi = ListType.LI,
   typeP = PARAGRAPH,
 }: ListTypeOptions = {}) => (e: KeyboardEvent, editor: Editor) => {
-  const options = { typeUl, typeOl, typeLi };
+  const options = { typeUl, typeOl, typeLi, typeP };
 
   if (Object.values(ListHotkey).includes(e.key)) {
-    if (editor.selection && isSelectionInList(editor)) {
+    if (editor.selection && isSelectionInList(editor, options)) {
       if (e.key === ListHotkey.TAB) {
         e.preventDefault();
       }
@@ -141,6 +141,7 @@ export const onKeyDownList = ({
       const deleteOnEmptyBlock =
         [ListHotkey.ENTER, ListHotkey.DELETE_BACKWARD].includes(e.key) &&
         isBlockTextEmpty(paragraphNode);
+
       if (shiftTab || deleteOnEmptyBlock) {
         const moved = moveUp(editor, listNode, listPath, listItemPath, options);
         if (moved) e.preventDefault();

--- a/packages/slate-plugins/src/elements/list/queries/isList.ts
+++ b/packages/slate-plugins/src/elements/list/queries/isList.ts
@@ -1,5 +1,5 @@
 import { Node } from 'slate';
-import { ListType } from '../types';
+import { defaultListTypes } from '../types';
 
-export const isList = (n: Node) =>
-  [ListType.OL_LIST, ListType.UL_LIST].includes(n.type);
+export const isList = (options = defaultListTypes) => (n: Node) =>
+  [options.typeOl, options.typeUl].includes(n.type);

--- a/packages/slate-plugins/src/elements/list/queries/isListItem.ts
+++ b/packages/slate-plugins/src/elements/list/queries/isListItem.ts
@@ -1,4 +1,5 @@
 import { Node } from 'slate';
-import { ListType } from '../types';
+import { defaultListTypes } from '../types';
 
-export const isListItem = (node: Node) => node.type === ListType.LIST_ITEM;
+export const isListItem = (options = defaultListTypes) => (node: Node) =>
+  node.type === options.typeLi;

--- a/packages/slate-plugins/src/elements/list/queries/isSelectionInList.ts
+++ b/packages/slate-plugins/src/elements/list/queries/isSelectionInList.ts
@@ -1,6 +1,8 @@
 import { Editor } from 'slate';
 import { isBlockActive } from '../../queries';
-import { ListType } from '../types';
+import { defaultListTypes } from '../types';
 
-export const isSelectionInList = (editor: Editor): boolean =>
-  isBlockActive(editor, ListType.LIST_ITEM);
+export const isSelectionInList = (
+  editor: Editor,
+  options = defaultListTypes
+): boolean => isBlockActive(editor, options.typeLi || '');

--- a/packages/slate-plugins/src/elements/list/renderElementList.tsx
+++ b/packages/slate-plugins/src/elements/list/renderElementList.tsx
@@ -15,8 +15,8 @@ const OlElement = styled.ol`
 `;
 
 export const renderElementList = ({
-  UL = UlElement,
-  OL = OlElement,
+  UL = getElementComponent(UlElement),
+  OL = getElementComponent(OlElement),
   LI = getElementComponent('li'),
   typeUl = ListType.UL,
   typeOl = ListType.OL,

--- a/packages/slate-plugins/src/elements/list/renderElementList.tsx
+++ b/packages/slate-plugins/src/elements/list/renderElementList.tsx
@@ -1,6 +1,4 @@
-import React from 'react';
-import { getElement } from 'elements/utils';
-import { RenderElementProps } from 'slate-react';
+import { getElementComponent, getRenderElements } from 'elements/utils';
 import styled from 'styled-components';
 import { ListType, RenderElementListOptions } from './types';
 
@@ -19,16 +17,13 @@ const OlElement = styled.ol`
 export const renderElementList = ({
   UL = UlElement,
   OL = OlElement,
-  LI = getElement('li'),
-}: RenderElementListOptions = {}) => (props: RenderElementProps) => {
-  switch (props.element.type) {
-    case ListType.UL_LIST:
-      return <UL {...props} />;
-    case ListType.OL_LIST:
-      return <OL {...props} />;
-    case ListType.LIST_ITEM:
-      return <LI {...props} />;
-    default:
-      break;
-  }
-};
+  LI = getElementComponent('li'),
+  typeUl = ListType.UL,
+  typeOl = ListType.OL,
+  typeLi = ListType.LI,
+}: RenderElementListOptions = {}) =>
+  getRenderElements([
+    { type: typeUl, component: UL },
+    { type: typeOl, component: OL },
+    { type: typeLi, component: LI },
+  ]);

--- a/packages/slate-plugins/src/elements/list/transforms/toggleList.ts
+++ b/packages/slate-plugins/src/elements/list/transforms/toggleList.ts
@@ -8,13 +8,29 @@ export const toggleList = (
   editor: Editor,
   {
     typeList,
+    typeUl = ListType.UL,
+    typeOl = ListType.OL,
     typeLi = ListType.LI,
     typeP = PARAGRAPH,
-  }: { typeList: string; typeLi?: string; typeP?: string }
+  }: {
+    typeList: string;
+    typeUl?: string;
+    typeOl?: string;
+    typeLi?: string;
+    typeP?: string;
+  }
 ) => {
+  const options = {
+    typeList,
+    typeUl,
+    typeOl,
+    typeLi,
+    typeP,
+  };
+
   const isActive = isBlockActive(editor, typeList);
 
-  unwrapList(editor);
+  unwrapList(editor, options);
 
   Transforms.setNodes(editor, {
     type: typeP,

--- a/packages/slate-plugins/src/elements/list/transforms/toggleList.ts
+++ b/packages/slate-plugins/src/elements/list/transforms/toggleList.ts
@@ -4,25 +4,32 @@ import { Editor, Transforms } from 'slate';
 import { ListType } from '../types';
 import { unwrapList } from './unwrapList';
 
-export const toggleList = (editor: Editor, listType: string) => {
-  const isActive = isBlockActive(editor, listType);
+export const toggleList = (
+  editor: Editor,
+  {
+    typeList,
+    typeLi = ListType.LI,
+    typeP = PARAGRAPH,
+  }: { typeList: string; typeLi?: string; typeP?: string }
+) => {
+  const isActive = isBlockActive(editor, typeList);
 
   unwrapList(editor);
 
   Transforms.setNodes(editor, {
-    type: PARAGRAPH,
+    type: typeP,
   });
 
   if (!isActive) {
-    const list = { type: listType, children: [] };
+    const list = { type: typeList, children: [] };
     Transforms.wrapNodes(editor, list);
 
     const nodesIterable = Editor.nodes(editor, {
-      match: (node) => node.type === PARAGRAPH,
+      match: (node) => node.type === typeP,
     });
     const nodes = [...nodesIterable];
 
-    const listItem = { type: ListType.LIST_ITEM, children: [] };
+    const listItem = { type: typeLi, children: [] };
 
     for (const [, path] of nodes) {
       Transforms.wrapNodes(editor, listItem, {

--- a/packages/slate-plugins/src/elements/list/transforms/unwrapList.ts
+++ b/packages/slate-plugins/src/elements/list/transforms/unwrapList.ts
@@ -1,13 +1,14 @@
+import { defaultListTypes } from 'elements/list/types';
 import { Editor, Transforms } from 'slate';
 import { isList, isListItem } from '../queries';
 
-export const unwrapList = (editor: Editor) => {
+export const unwrapList = (editor: Editor, options = defaultListTypes) => {
   Transforms.unwrapNodes(editor, {
-    match: isListItem,
+    match: isListItem(options),
   });
 
   Transforms.unwrapNodes(editor, {
-    match: isList,
+    match: isList(options),
     split: true,
   });
 };

--- a/packages/slate-plugins/src/elements/list/types.ts
+++ b/packages/slate-plugins/src/elements/list/types.ts
@@ -1,3 +1,5 @@
+import { PARAGRAPH } from 'elements/paragraph';
+
 export const ListHotkey = {
   TAB: 'Tab',
   ENTER: 'Enter',
@@ -5,13 +7,27 @@ export const ListHotkey = {
 };
 
 export enum ListType {
-  OL_LIST = 'numbered-list',
-  UL_LIST = 'bulleted-list',
-  LIST_ITEM = 'list-item',
+  OL = 'numbered-list',
+  UL = 'bulleted-list',
+  LI = 'list-item',
 }
 
-export interface RenderElementListOptions {
+export interface ListTypeOptions {
+  typeUl?: string;
+  typeOl?: string;
+  typeLi?: string;
+  typeP?: string;
+}
+
+export interface RenderElementListOptions extends ListTypeOptions {
   UL?: any;
   OL?: any;
   LI?: any;
 }
+
+export const defaultListTypes: ListTypeOptions = {
+  typeUl: ListType.UL,
+  typeOl: ListType.OL,
+  typeLi: ListType.LI,
+  typeP: PARAGRAPH,
+};

--- a/packages/slate-plugins/src/elements/list/types.ts
+++ b/packages/slate-plugins/src/elements/list/types.ts
@@ -7,9 +7,9 @@ export const ListHotkey = {
 };
 
 export enum ListType {
-  OL = 'numbered-list',
-  UL = 'bulleted-list',
-  LI = 'list-item',
+  OL = 'ol',
+  UL = 'ul',
+  LI = 'li',
 }
 
 export interface ListTypeOptions {

--- a/packages/slate-plugins/src/elements/list/withList.ts
+++ b/packages/slate-plugins/src/elements/list/withList.ts
@@ -10,6 +10,13 @@ export const withList = ({
   typeLi = ListType.LI,
   typeP = PARAGRAPH,
 }: ListTypeOptions = {}) => <T extends Editor>(editor: T) => {
+  const options = {
+    typeUl,
+    typeOl,
+    typeLi,
+    typeP,
+  };
+
   const { insertBreak } = editor;
 
   /**
@@ -118,13 +125,13 @@ export const withList = ({
   };
 
   let e = withBreakEmptyReset({
-    typeP,
+    ...options,
     types: [typeLi],
     onUnwrap: withBreakEmptyList,
   })(editor);
 
   e = withDeleteStartReset({
-    typeP,
+    ...options,
     types: [typeLi],
     onUnwrap: withBreakEmptyList,
   })(e);

--- a/packages/slate-plugins/src/elements/mention/MentionPlugin.ts
+++ b/packages/slate-plugins/src/elements/mention/MentionPlugin.ts
@@ -1,6 +1,6 @@
+import { renderElementMention } from 'elements/mention/renderElementMention';
 import { SlatePlugin } from 'types';
 import { RenderElementOptions } from '../types';
-import { renderElementMention } from './renderElementMention';
 
 export const MentionPlugin = (options?: RenderElementOptions): SlatePlugin => ({
   renderElement: renderElementMention(options),

--- a/packages/slate-plugins/src/elements/mention/components/MentionElement.tsx
+++ b/packages/slate-plugins/src/elements/mention/components/MentionElement.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { RenderElementProps, useFocused, useSelected } from 'slate-react';
-import { MENTION } from '../types';
 
 export const MentionElement = ({
   attributes,
@@ -13,7 +12,6 @@ export const MentionElement = ({
   return (
     <span
       {...attributes}
-      data-slate-type={MENTION}
       contentEditable={false}
       style={{
         padding: '3px 3px 2px',

--- a/packages/slate-plugins/src/elements/mention/renderElementMention.ts
+++ b/packages/slate-plugins/src/elements/mention/renderElementMention.ts
@@ -1,0 +1,13 @@
+import { RenderElementOptions } from 'elements/types';
+import { getRenderElement } from '../utils';
+import { MentionElement } from './components';
+import { MENTION } from './types';
+
+export const renderElementMention = ({
+  typeMention = MENTION,
+  component = MentionElement,
+}: RenderElementOptions = {}) =>
+  getRenderElement({
+    type: typeMention,
+    component,
+  });

--- a/packages/slate-plugins/src/elements/mention/renderElementMention.tsx
+++ b/packages/slate-plugins/src/elements/mention/renderElementMention.tsx
@@ -1,8 +1,0 @@
-import { getRenderElement } from '../utils';
-import { MentionElement } from './components';
-import { MENTION } from './types';
-
-export const renderElementMention = getRenderElement({
-  type: MENTION,
-  component: MentionElement,
-});

--- a/packages/slate-plugins/src/elements/mention/withMention.ts
+++ b/packages/slate-plugins/src/elements/mention/withMention.ts
@@ -3,9 +3,13 @@ import { withVoid } from 'elements/withVoid';
 import { Editor } from 'slate';
 import { MENTION } from './types';
 
-export const withMention = <T extends Editor>(editor: T) => {
-  editor = withVoid([MENTION])(editor);
-  editor = withInline([MENTION])(editor);
+export const withMention = ({ typeMention = MENTION } = {}) => <
+  T extends Editor
+>(
+  editor: T
+) => {
+  editor = withVoid([typeMention])(editor);
+  editor = withInline([typeMention])(editor);
 
   return editor;
 };

--- a/packages/slate-plugins/src/elements/paragraph/ParagraphPlugin.ts
+++ b/packages/slate-plugins/src/elements/paragraph/ParagraphPlugin.ts
@@ -4,8 +4,8 @@ import { deserializeParagraph } from './deserializeParagraph';
 import { renderElementParagraph } from './renderElementParagraph';
 
 export const ParagraphPlugin = (
-  options?: RenderElementOptions
+  options?: RenderElementOptions & { typeP?: string }
 ): SlatePlugin => ({
   renderElement: renderElementParagraph(options),
-  deserialize: deserializeParagraph(),
+  deserialize: deserializeParagraph(options),
 });

--- a/packages/slate-plugins/src/elements/paragraph/deserializeParagraph.ts
+++ b/packages/slate-plugins/src/elements/paragraph/deserializeParagraph.ts
@@ -1,8 +1,10 @@
 import { DeserializeHtml } from 'deserializers/types';
 import { PARAGRAPH } from './types';
 
-export const deserializeParagraph = (): DeserializeHtml => ({
+export const deserializeParagraph = ({
+  typeP = PARAGRAPH,
+} = {}): DeserializeHtml => ({
   element: {
-    P: () => ({ type: PARAGRAPH }),
+    P: () => ({ type: typeP }),
   },
 });

--- a/packages/slate-plugins/src/elements/paragraph/renderElementParagraph.ts
+++ b/packages/slate-plugins/src/elements/paragraph/renderElementParagraph.ts
@@ -1,7 +1,12 @@
-import { getElement, getRenderElement } from '../utils';
+import { RenderElementOptions } from 'elements/types';
+import { getElementComponent, getRenderElement } from '../utils';
 import { PARAGRAPH } from './types';
 
-export const renderElementParagraph = getRenderElement({
-  type: PARAGRAPH,
-  component: getElement('div'),
-});
+export const renderElementParagraph = ({
+  typeP = PARAGRAPH,
+  component = getElementComponent('div'),
+}: RenderElementOptions = {}) =>
+  getRenderElement({
+    type: typeP,
+    component,
+  });

--- a/packages/slate-plugins/src/elements/paragraph/types.ts
+++ b/packages/slate-plugins/src/elements/paragraph/types.ts
@@ -1,1 +1,1 @@
-export const PARAGRAPH = 'paragraph';
+export const PARAGRAPH = 'p';

--- a/packages/slate-plugins/src/elements/table/TablePlugin.ts
+++ b/packages/slate-plugins/src/elements/table/TablePlugin.ts
@@ -7,5 +7,5 @@ export const TablePlugin = (
   options?: RenderElementTableOptions
 ): SlatePlugin => ({
   renderElement: renderElementTable(options),
-  deserialize: deserializeTable(),
+  deserialize: deserializeTable(options),
 });

--- a/packages/slate-plugins/src/elements/table/components/TableCell.tsx
+++ b/packages/slate-plugins/src/elements/table/components/TableCell.tsx
@@ -1,0 +1,6 @@
+import styled from 'styled-components';
+
+export const TableCell = styled.td`
+  padding: 10px;
+  border: 2px solid #ddd;
+`;

--- a/packages/slate-plugins/src/elements/table/components/TableElement.tsx
+++ b/packages/slate-plugins/src/elements/table/components/TableElement.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { RenderElementProps } from 'slate-react';
+import styled from 'styled-components';
+
+export const StyledTable = styled.table`
+  margin: 10px 0;
+  border-collapse: collapse;
+  width: 100%;
+`;
+
+export const TableElement = ({ attributes, children }: RenderElementProps) => (
+  <StyledTable {...attributes}>
+    <tbody>{children}</tbody>
+  </StyledTable>
+);

--- a/packages/slate-plugins/src/elements/table/components/ToolbarTable.tsx
+++ b/packages/slate-plugins/src/elements/table/components/ToolbarTable.tsx
@@ -1,16 +1,25 @@
 import React from 'react';
+import { ToolbarButton, ToolbarButtonProps } from 'common/components';
+import { TableType, TableTypeOptions } from 'elements/table/types';
 import { Editor } from 'slate';
 import { useSlate } from 'slate-react';
-import { ToolbarButton, ToolbarButtonProps } from '../../../common/components';
 import { isSelectionInTable } from '../queries';
 
-export interface ToolbarTableProps extends ToolbarButtonProps {
-  action: (editor: Editor) => void;
+export interface ToolbarTableProps
+  extends ToolbarButtonProps,
+    TableTypeOptions {
+  action: (editor: Editor, options: TableTypeOptions) => void;
 }
 
-export const ToolbarTable = (props: ToolbarTableProps) => {
+export const ToolbarTable = ({
+  action,
+  typeTable = TableType.TABLE,
+  typeTr = TableType.ROW,
+  typeTd = TableType.CELL,
+  ...props
+}: ToolbarTableProps) => {
   const editor = useSlate();
-  const isTableActive = isSelectionInTable(editor);
+  const isTableActive = isSelectionInTable(editor, { typeTable });
 
   return (
     <ToolbarButton
@@ -18,7 +27,7 @@ export const ToolbarTable = (props: ToolbarTableProps) => {
       active={isTableActive}
       onMouseDown={(event: Event) => {
         event.preventDefault();
-        props.action(editor);
+        action(editor, { typeTable, typeTr, typeTd });
       }}
     />
   );

--- a/packages/slate-plugins/src/elements/table/components/index.ts
+++ b/packages/slate-plugins/src/elements/table/components/index.ts
@@ -1,1 +1,3 @@
 export * from './ToolbarTable';
+export * from './TableCell';
+export * from './TableElement';

--- a/packages/slate-plugins/src/elements/table/deserializeTable.ts
+++ b/packages/slate-plugins/src/elements/table/deserializeTable.ts
@@ -1,10 +1,14 @@
 import { DeserializeHtml } from 'deserializers/types';
-import { TableType } from './types';
+import { TableType, TableTypeOptions } from './types';
 
-export const deserializeTable = (): DeserializeHtml => ({
+export const deserializeTable = ({
+  typeTable = TableType.TABLE,
+  typeTr = TableType.ROW,
+  typeTd = TableType.CELL,
+}: TableTypeOptions = {}): DeserializeHtml => ({
   element: {
-    TABLE: () => ({ type: TableType.TABLE }),
-    TR: () => ({ type: TableType.ROW }),
-    TD: () => ({ type: TableType.CELL }),
+    TABLE: () => ({ type: typeTable }),
+    TR: () => ({ type: typeTr }),
+    TD: () => ({ type: typeTd }),
   },
 });

--- a/packages/slate-plugins/src/elements/table/queries/isSelectionInTable.ts
+++ b/packages/slate-plugins/src/elements/table/queries/isSelectionInTable.ts
@@ -1,6 +1,8 @@
 import { Editor } from 'slate';
 import { isBlockActive } from '../../queries';
-import { TableType } from '../types';
+import { defaultTableTypes } from '../types';
 
-export const isSelectionInTable = (editor: Editor): boolean =>
-  isBlockActive(editor, TableType.TABLE);
+export const isSelectionInTable = (
+  editor: Editor,
+  options = defaultTableTypes
+): boolean => isBlockActive(editor, options.typeTable || '');

--- a/packages/slate-plugins/src/elements/table/queries/isTable.ts
+++ b/packages/slate-plugins/src/elements/table/queries/isTable.ts
@@ -1,4 +1,5 @@
 import { Node } from 'slate';
-import { TableType } from '../types';
+import { defaultTableTypes } from '../types';
 
-export const isTable = (n: Node) => n.type === TableType.TABLE;
+export const isTable = (options = defaultTableTypes) => (n: Node) =>
+  n.type === options.typeTable;

--- a/packages/slate-plugins/src/elements/table/queries/isTableCell.ts
+++ b/packages/slate-plugins/src/elements/table/queries/isTableCell.ts
@@ -1,4 +1,5 @@
 import { Node } from 'slate';
-import { TableType } from '../types';
+import { defaultTableTypes } from '../types';
 
-export const isTableCell = (n: Node) => n.type === TableType.CELL;
+export const isTableCell = (options = defaultTableTypes) => (n: Node) =>
+  n.type === options.typeTd;

--- a/packages/slate-plugins/src/elements/table/queries/isTableRow.ts
+++ b/packages/slate-plugins/src/elements/table/queries/isTableRow.ts
@@ -1,4 +1,5 @@
 import { Node } from 'slate';
-import { TableType } from '../types';
+import { defaultTableTypes } from '../types';
 
-export const isTableRow = (n: Node) => n.type === TableType.ROW;
+export const isTableRow = (options = defaultTableTypes) => (n: Node) =>
+  n.type === options.typeTr;

--- a/packages/slate-plugins/src/elements/table/renderElementTable.tsx
+++ b/packages/slate-plugins/src/elements/table/renderElementTable.tsx
@@ -1,39 +1,18 @@
-import React from 'react';
-import { RenderElementProps } from 'slate-react';
-import styled from 'styled-components';
-import { getElement } from '../utils';
+import { TableCell } from 'elements/table/components/TableCell';
+import { TableElement } from 'elements/table/components/TableElement';
+import { getElementComponent, getRenderElements } from '../utils';
 import { RenderElementTableOptions, TableType } from './types';
-
-const StyledTable = styled.table`
-  margin: 10px 0;
-  border-collapse: collapse;
-  width: 100%;
-`;
-
-const Td = styled.td`
-  padding: 10px;
-  border: 2px solid #ddd;
-`;
-
-const TableElement = ({ attributes, children }: RenderElementProps) => (
-  <StyledTable {...attributes} data-slate-type={TableType.TABLE}>
-    <tbody>{children}</tbody>
-  </StyledTable>
-);
 
 export const renderElementTable = ({
   Table = TableElement,
-  Row = getElement('tr'),
-  Cell = Td,
-}: RenderElementTableOptions = {}) => (props: RenderElementProps) => {
-  switch (props.element.type) {
-    case TableType.TABLE:
-      return <Table {...props} />;
-    case TableType.ROW:
-      return <Row {...props} />;
-    case TableType.CELL:
-      return <Cell {...props} />;
-    default:
-      break;
-  }
-};
+  Row = getElementComponent('tr'),
+  Cell = TableCell,
+  typeTable = TableType.TABLE,
+  typeTr = TableType.ROW,
+  typeTd = TableType.CELL,
+}: RenderElementTableOptions = {}) =>
+  getRenderElements([
+    { component: Table, type: typeTable },
+    { component: Row, type: typeTr },
+    { component: Cell, type: typeTd },
+  ]);

--- a/packages/slate-plugins/src/elements/table/renderElementTable.tsx
+++ b/packages/slate-plugins/src/elements/table/renderElementTable.tsx
@@ -6,7 +6,7 @@ import { RenderElementTableOptions, TableType } from './types';
 export const renderElementTable = ({
   Table = TableElement,
   Row = getElementComponent('tr'),
-  Cell = TableCell,
+  Cell = getElementComponent(TableCell),
   typeTable = TableType.TABLE,
   typeTr = TableType.ROW,
   typeTd = TableType.CELL,

--- a/packages/slate-plugins/src/elements/table/transforms/addColumn.ts
+++ b/packages/slate-plugins/src/elements/table/transforms/addColumn.ts
@@ -1,14 +1,14 @@
 import { Editor, Path, Transforms } from 'slate';
 import { isSelectionInTable, isTable, isTableCell } from '../queries';
-import { emptyCell } from '../types';
+import { defaultTableTypes, emptyCell } from '../types';
 
-export const addColumn = (editor: Editor) => {
-  if (isSelectionInTable(editor)) {
+export const addColumn = (editor: Editor, options = defaultTableTypes) => {
+  if (isSelectionInTable(editor, options)) {
     const currentCellItem = Editor.above(editor, {
-      match: isTableCell,
+      match: isTableCell(options),
     });
     const currentTableItem = Editor.above(editor, {
-      match: isTable,
+      match: isTable(options),
     });
     if (currentCellItem && currentTableItem) {
       const nextCellPath = Path.next(currentCellItem[1]);
@@ -19,7 +19,7 @@ export const addColumn = (editor: Editor) => {
       currentTableItem[0].children.forEach((row, rowIdx) => {
         newCellPath[replacePathPos] = rowIdx;
 
-        Transforms.insertNodes(editor, emptyCell(), {
+        Transforms.insertNodes(editor, emptyCell(options), {
           at: newCellPath,
           select: rowIdx === currentRowIdx,
         });

--- a/packages/slate-plugins/src/elements/table/transforms/addRow.ts
+++ b/packages/slate-plugins/src/elements/table/transforms/addRow.ts
@@ -1,18 +1,22 @@
 import { Editor, Path, Transforms } from 'slate';
 import { isSelectionInTable, isTableRow } from '../queries';
-import { emptyRow } from '../types';
+import { defaultTableTypes, emptyRow } from '../types';
 
-export const addRow = (editor: Editor) => {
-  if (isSelectionInTable(editor)) {
+export const addRow = (editor: Editor, options = defaultTableTypes) => {
+  if (isSelectionInTable(editor, options)) {
     const currentRowItem = Editor.above(editor, {
-      match: isTableRow,
+      match: isTableRow(options),
     });
     if (currentRowItem) {
       const [currentRowElem, currentRowPath] = currentRowItem;
-      Transforms.insertNodes(editor, emptyRow(currentRowElem.children.length), {
-        at: Path.next(currentRowPath),
-        select: true,
-      });
+      Transforms.insertNodes(
+        editor,
+        emptyRow(currentRowElem.children.length, options),
+        {
+          at: Path.next(currentRowPath),
+          select: true,
+        }
+      );
     }
   }
 };

--- a/packages/slate-plugins/src/elements/table/transforms/deleteColumn.ts
+++ b/packages/slate-plugins/src/elements/table/transforms/deleteColumn.ts
@@ -1,3 +1,4 @@
+import { defaultTableTypes } from 'elements/table/types';
 import { Editor, Transforms } from 'slate';
 import {
   isSelectionInTable,
@@ -6,16 +7,16 @@ import {
   isTableRow,
 } from '../queries';
 
-export const deleteColumn = (editor: Editor) => {
-  if (isSelectionInTable(editor)) {
+export const deleteColumn = (editor: Editor, options = defaultTableTypes) => {
+  if (isSelectionInTable(editor, options)) {
     const currentCellItem = Editor.above(editor, {
-      match: isTableCell,
+      match: isTableCell(options),
     });
     const currentRowItem = Editor.above(editor, {
-      match: isTableRow,
+      match: isTableRow(options),
     });
     const currentTableItem = Editor.above(editor, {
-      match: isTable,
+      match: isTable(options),
     });
     if (
       currentCellItem &&

--- a/packages/slate-plugins/src/elements/table/transforms/deleteRow.ts
+++ b/packages/slate-plugins/src/elements/table/transforms/deleteRow.ts
@@ -1,13 +1,14 @@
+import { defaultTableTypes } from 'elements/table/types';
 import { Editor, Transforms } from 'slate';
 import { isSelectionInTable, isTable, isTableRow } from '../queries';
 
-export const deleteRow = (editor: Editor) => {
-  if (isSelectionInTable(editor)) {
+export const deleteRow = (editor: Editor, options = defaultTableTypes) => {
+  if (isSelectionInTable(editor, options)) {
     const currentTableItem = Editor.above(editor, {
-      match: isTable,
+      match: isTable(options),
     });
     const currentRowItem = Editor.above(editor, {
-      match: isTableRow,
+      match: isTableRow(options),
     });
     if (
       currentRowItem &&

--- a/packages/slate-plugins/src/elements/table/transforms/deleteTable.ts
+++ b/packages/slate-plugins/src/elements/table/transforms/deleteTable.ts
@@ -1,10 +1,11 @@
+import { defaultTableTypes } from 'elements/table/types';
 import { Editor, Transforms } from 'slate';
 import { isSelectionInTable, isTable } from '../queries';
 
-export const deleteTable = (editor: Editor) => {
-  if (isSelectionInTable(editor)) {
+export const deleteTable = (editor: Editor, options = defaultTableTypes) => {
+  if (isSelectionInTable(editor, options)) {
     const tableItem = Editor.above(editor, {
-      match: isTable,
+      match: isTable(options),
     });
     if (tableItem) {
       Transforms.removeNodes(editor, {

--- a/packages/slate-plugins/src/elements/table/transforms/insertTable.ts
+++ b/packages/slate-plugins/src/elements/table/transforms/insertTable.ts
@@ -1,9 +1,9 @@
 import { Editor, Transforms } from 'slate';
 import { isSelectionInTable } from '../queries';
-import { emptyTable } from '../types';
+import { defaultTableTypes, emptyTable } from '../types';
 
-export const insertTable = (editor: Editor) => {
-  if (!isSelectionInTable(editor)) {
-    Transforms.insertNodes(editor, emptyTable());
+export const insertTable = (editor: Editor, options = defaultTableTypes) => {
+  if (!isSelectionInTable(editor, options)) {
+    Transforms.insertNodes(editor, emptyTable(options));
   }
 };

--- a/packages/slate-plugins/src/elements/table/types.ts
+++ b/packages/slate-plugins/src/elements/table/types.ts
@@ -1,7 +1,7 @@
 export enum TableType {
   TABLE = 'table',
-  ROW = 'table-row',
-  CELL = 'table-cell',
+  ROW = 'tr',
+  CELL = 'td',
 }
 
 export interface TableTypeOptions {

--- a/packages/slate-plugins/src/elements/table/types.ts
+++ b/packages/slate-plugins/src/elements/table/types.ts
@@ -4,25 +4,37 @@ export enum TableType {
   CELL = 'table-cell',
 }
 
-export interface RenderElementTableOptions {
+export interface TableTypeOptions {
+  typeTable?: string;
+  typeTr?: string;
+  typeTd?: string;
+}
+
+export interface RenderElementTableOptions extends TableTypeOptions {
   Table?: any;
   Row?: any;
   Cell?: any;
 }
 
-export const emptyCell = () => ({
-  type: TableType.CELL,
+export const defaultTableTypes: TableTypeOptions = {
+  typeTable: TableType.TABLE,
+  typeTr: TableType.ROW,
+  typeTd: TableType.CELL,
+};
+
+export const emptyCell = (options = defaultTableTypes) => ({
+  type: options.typeTd,
   children: [{ text: '' }],
 });
 
-export const emptyRow = (colCount: number) => ({
-  type: TableType.ROW,
+export const emptyRow = (colCount: number, options = defaultTableTypes) => ({
+  type: options.typeTr,
   children: Array(colCount)
     .fill(colCount)
-    .map(() => emptyCell()),
+    .map(() => emptyCell(options)),
 });
 
-export const emptyTable = () => ({
-  type: TableType.TABLE,
-  children: [emptyRow(2), emptyRow(2)],
+export const emptyTable = (options = defaultTableTypes) => ({
+  type: options.typeTable,
+  children: [emptyRow(2, options), emptyRow(2, options)],
 });

--- a/packages/slate-plugins/src/elements/types.ts
+++ b/packages/slate-plugins/src/elements/types.ts
@@ -11,4 +11,5 @@ export interface GetRenderElementOptions {
 
 export interface RenderElementOptions {
   component?: any;
+  [key: string]: any;
 }

--- a/packages/slate-plugins/src/elements/utils/getElementComponent.tsx
+++ b/packages/slate-plugins/src/elements/utils/getElementComponent.tsx
@@ -2,14 +2,14 @@ import React from 'react';
 import { RenderElementProps } from 'slate-react';
 
 /**
- * get default element component
+ * Get default element component
  */
 export const getElementComponent = (Component: any) => ({
   attributes,
   element,
   children,
 }: RenderElementProps) => (
-  <Component {...attributes} data-slate-type={element.type}>
+  <Component data-slate-type={element.type} {...attributes}>
     {children}
   </Component>
 );

--- a/packages/slate-plugins/src/elements/utils/getElementComponent.tsx
+++ b/packages/slate-plugins/src/elements/utils/getElementComponent.tsx
@@ -4,7 +4,7 @@ import { RenderElementProps } from 'slate-react';
 /**
  * get default element component
  */
-export const getElement = (Component: any) => ({
+export const getElementComponent = (Component: any) => ({
   attributes,
   element,
   children,

--- a/packages/slate-plugins/src/elements/utils/getRenderElement.tsx
+++ b/packages/slate-plugins/src/elements/utils/getRenderElement.tsx
@@ -1,18 +1,42 @@
 import React from 'react';
 import { RenderElementProps } from 'slate-react';
-import { GetRenderElementOptions, RenderElementOptions } from '../types';
+import { GetRenderElementOptions } from '../types';
 
 /**
- * get generic renderElement with a custom component
+ * Get generic renderElement from a possible type + component
  */
 export const getRenderElement = ({
   type,
-  component,
+  component: Component,
 }: GetRenderElementOptions) => ({
-  component: Component = component,
-}: RenderElementOptions = {}) => (props: RenderElementProps) => {
-  const elementType = props.element.type;
-  if (elementType === type) {
-    return <Component {...props} />;
+  attributes,
+  ...props
+}: RenderElementProps) => {
+  if (props.element.type === type) {
+    return (
+      <Component
+        attributes={{ 'data-slate-type': type, ...attributes }}
+        {...props}
+      />
+    );
+  }
+};
+
+/**
+ * Get generic renderElement from a list of possible types + components
+ */
+export const getRenderElements = (options: GetRenderElementOptions[]) => ({
+  attributes,
+  ...props
+}: RenderElementProps) => {
+  for (const { type, component: Component } of options) {
+    if (props.element.type === type) {
+      return (
+        <Component
+          attributes={{ 'data-slate-type': type, ...attributes }}
+          {...props}
+        />
+      );
+    }
   }
 };

--- a/packages/slate-plugins/src/elements/utils/index.ts
+++ b/packages/slate-plugins/src/elements/utils/index.ts
@@ -1,2 +1,2 @@
-export * from './getElement';
+export * from 'elements/utils/getElementComponent';
 export * from './getRenderElement';

--- a/packages/slate-plugins/src/elements/video/components/VideoElement.tsx
+++ b/packages/slate-plugins/src/elements/video/components/VideoElement.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Transforms } from 'slate';
 import { ReactEditor, RenderElementProps, useEditor } from 'slate-react';
 import styled from 'styled-components';
-import { VIDEO } from '../types';
 
 const VideoWrapper = styled.div`
   padding: 75% 0 0 0;
@@ -51,7 +50,7 @@ export const VideoElement = ({
   const { url } = element;
 
   return (
-    <div {...attributes} data-slate-type={VIDEO}>
+    <div {...attributes}>
       <div contentEditable={false}>
         <VideoWrapper>
           <Iframe

--- a/packages/slate-plugins/src/elements/video/index.ts
+++ b/packages/slate-plugins/src/elements/video/index.ts
@@ -2,4 +2,3 @@ export * from './components';
 export * from './renderElementVideo';
 export * from './types';
 export * from './VideoPlugin';
-export * from './withVideo';

--- a/packages/slate-plugins/src/elements/video/renderElementVideo.ts
+++ b/packages/slate-plugins/src/elements/video/renderElementVideo.ts
@@ -1,8 +1,13 @@
+import { RenderElementOptions } from 'elements/types';
 import { getRenderElement } from '../utils';
 import { VideoElement } from './components';
 import { VIDEO } from './types';
 
-export const renderElementVideo = getRenderElement({
-  type: VIDEO,
-  component: VideoElement,
-});
+export const renderElementVideo = ({
+  typeVideo = VIDEO,
+  component = VideoElement,
+}: RenderElementOptions = {}) =>
+  getRenderElement({
+    type: typeVideo,
+    component,
+  });

--- a/packages/slate-plugins/src/elements/video/withVideo.ts
+++ b/packages/slate-plugins/src/elements/video/withVideo.ts
@@ -1,9 +1,0 @@
-import { withVoid } from 'elements/withVoid';
-import { Editor } from 'slate';
-import { VIDEO } from './types';
-
-export const withVideo = <T extends Editor>(editor: T) => {
-  editor = withVoid([VIDEO])(editor);
-
-  return editor;
-};

--- a/packages/slate-plugins/src/elements/withBlock.ts
+++ b/packages/slate-plugins/src/elements/withBlock.ts
@@ -3,14 +3,16 @@ import { PARAGRAPH } from './paragraph';
 import { isBlockActive } from './queries';
 import { ToggleBlockEditor } from './types';
 
-export const withBlock = <T extends Editor>(editor: T) => {
+export const withBlock = ({ typeP = PARAGRAPH } = {}) => <T extends Editor>(
+  editor: T
+) => {
   const e = editor as T & ToggleBlockEditor;
 
-  e.toggleBlock = (format: string) => {
-    const isActive = isBlockActive(e, format);
+  e.toggleBlock = (type: string) => {
+    const isActive = isBlockActive(e, type);
 
     Transforms.setNodes(e, {
-      type: isActive ? PARAGRAPH : format,
+      type: isActive ? typeP : type,
     });
   };
 

--- a/packages/slate-plugins/src/elements/withBreakEmptyReset.ts
+++ b/packages/slate-plugins/src/elements/withBreakEmptyReset.ts
@@ -8,9 +8,11 @@ import { isBlockTextEmpty } from './queries';
  */
 export const withBreakEmptyReset = ({
   types,
+  typeP = PARAGRAPH,
   onUnwrap,
 }: {
   types: string[];
+  typeP?: string;
   onUnwrap?: any;
 }) => <T extends Editor>(editor: T) => {
   const { insertBreak } = editor;
@@ -29,7 +31,7 @@ export const withBreakEmptyReset = ({
         });
 
         if (parent) {
-          Transforms.setNodes(editor, { type: PARAGRAPH });
+          Transforms.setNodes(editor, { type: typeP });
 
           if (onUnwrap) onUnwrap();
 

--- a/packages/slate-plugins/src/elements/withDeleteStartReset.ts
+++ b/packages/slate-plugins/src/elements/withDeleteStartReset.ts
@@ -6,9 +6,11 @@ import { Editor, Point, Range, Transforms } from 'slate';
  * replace it with a new paragraph.
  */
 export const withDeleteStartReset = ({
+  typeP = PARAGRAPH,
   types,
   onUnwrap,
 }: {
+  typeP?: string;
   types: string[];
   onUnwrap?: any;
 }) => <T extends Editor>(editor: T) => {
@@ -27,7 +29,7 @@ export const withDeleteStartReset = ({
         const parentStart = Editor.start(editor, parentPath);
 
         if (Point.equals(selection.anchor, parentStart)) {
-          Transforms.setNodes(editor, { type: PARAGRAPH });
+          Transforms.setNodes(editor, { type: typeP });
 
           if (onUnwrap) onUnwrap();
 

--- a/packages/slate-plugins/src/forced-layout/withForcedLayout.ts
+++ b/packages/slate-plugins/src/forced-layout/withForcedLayout.ts
@@ -1,14 +1,17 @@
 import { HeadingType, PARAGRAPH } from 'elements';
 import { Editor, Node, Transforms } from 'slate';
 
-export const withForcedLayout = <T extends Editor>(editor: T) => {
+export const withForcedLayout = ({
+  typeH1 = HeadingType.H1,
+  typeP = PARAGRAPH,
+}) => <T extends Editor>(editor: T) => {
   const { normalizeNode } = editor;
 
   editor.normalizeNode = ([node, path]) => {
     if (path.length === 0) {
       if (editor.children.length < 1) {
         const title = {
-          type: HeadingType.H1,
+          type: typeH1,
           children: [{ text: 'Untitled' }],
         };
         Transforms.insertNodes(editor, title, { at: path.concat(0) });
@@ -16,14 +19,14 @@ export const withForcedLayout = <T extends Editor>(editor: T) => {
 
       if (editor.children.length < 2) {
         const paragraph = {
-          type: PARAGRAPH,
+          type: typeP,
           children: [{ text: '' }],
         };
         Transforms.insertNodes(editor, paragraph, { at: path.concat(1) });
       }
 
       for (const [child, childPath] of Node.children(editor, path)) {
-        const type = childPath[0] === 0 ? HeadingType.H1 : PARAGRAPH;
+        const type = childPath[0] === 0 ? typeH1 : typeP;
 
         if (child.type !== type) {
           Transforms.setNodes(editor, { type }, { at: childPath });

--- a/packages/slate-plugins/src/markdown-shortcuts/withShortcuts.ts
+++ b/packages/slate-plugins/src/markdown-shortcuts/withShortcuts.ts
@@ -1,20 +1,18 @@
 import { BLOCKQUOTE, HeadingType, ListType, toggleList } from 'elements';
 import { Editor, Range, Transforms } from 'slate';
 
-const SHORTCUTS: { [key: string]: string } = {
-  '*': ListType.LIST_ITEM,
-  '-': ListType.LIST_ITEM,
-  '+': ListType.LIST_ITEM,
-  '>': BLOCKQUOTE,
-  '#': HeadingType.H1,
-  '##': HeadingType.H2,
-  '###': HeadingType.H3,
-  '####': HeadingType.H4,
-  '#####': HeadingType.H5,
-  '######': HeadingType.H6,
-};
-
-export const withShortcuts = <T extends Editor>(editor: T) => {
+export const withShortcuts = ({
+  typeUl = ListType.UL,
+  typeOl = ListType.OL,
+  typeLi = ListType.LI,
+  typeBlockquote = BLOCKQUOTE,
+  typeH1 = HeadingType.H1,
+  typeH2 = HeadingType.H2,
+  typeH3 = HeadingType.H3,
+  typeH4 = HeadingType.H4,
+  typeH5 = HeadingType.H5,
+  typeH6 = HeadingType.H6,
+} = {}) => <T extends Editor>(editor: T) => {
   const { insertText } = editor;
 
   editor.insertText = (text) => {
@@ -29,18 +27,35 @@ export const withShortcuts = <T extends Editor>(editor: T) => {
       const start = Editor.start(editor, path);
       const range = { anchor, focus: start };
       const beforeText = Editor.string(editor, range);
+
+      const SHORTCUTS: { [key: string]: string } = {
+        '*': typeLi,
+        '-': typeLi,
+        '+': typeLi,
+        '1.': typeLi,
+        '>': typeBlockquote,
+        '#': typeH1,
+        '##': typeH2,
+        '###': typeH3,
+        '####': typeH4,
+        '#####': typeH5,
+        '######': typeH6,
+      };
+
       const type = SHORTCUTS[beforeText];
       if (type) {
         Transforms.select(editor, range);
         Transforms.delete(editor);
-        if (type !== ListType.LIST_ITEM) {
+        if (type !== typeLi) {
           Transforms.setNodes(
             editor,
             { type },
             { match: (n) => Editor.isBlock(editor, n) }
           );
         } else {
-          toggleList(editor, ListType.UL_LIST);
+          const typeList = beforeText === '1.' ? typeOl : typeUl;
+
+          toggleList(editor, { typeList, typeLi });
         }
         return;
       }

--- a/packages/slate-plugins/src/markdown-shortcuts/withShortcuts.ts
+++ b/packages/slate-plugins/src/markdown-shortcuts/withShortcuts.ts
@@ -1,18 +1,39 @@
-import { BLOCKQUOTE, HeadingType, ListType, toggleList } from 'elements';
+import {
+  BLOCKQUOTE,
+  HeadingType,
+  ListType,
+  PARAGRAPH,
+  toggleList,
+} from 'elements';
 import { Editor, Range, Transforms } from 'slate';
 
 export const withShortcuts = ({
   typeUl = ListType.UL,
   typeOl = ListType.OL,
   typeLi = ListType.LI,
-  typeBlockquote = BLOCKQUOTE,
   typeH1 = HeadingType.H1,
   typeH2 = HeadingType.H2,
   typeH3 = HeadingType.H3,
   typeH4 = HeadingType.H4,
   typeH5 = HeadingType.H5,
   typeH6 = HeadingType.H6,
+  typeBlockquote = BLOCKQUOTE,
+  typeP = PARAGRAPH,
 } = {}) => <T extends Editor>(editor: T) => {
+  const options = {
+    typeUl,
+    typeOl,
+    typeLi,
+    typeBlockquote,
+    typeH1,
+    typeH2,
+    typeH3,
+    typeH4,
+    typeH5,
+    typeH6,
+    typeP,
+  };
+
   const { insertText } = editor;
 
   editor.insertText = (text) => {
@@ -55,7 +76,7 @@ export const withShortcuts = ({
         } else {
           const typeList = beforeText === '1.' ? typeOl : typeUl;
 
-          toggleList(editor, { typeList, typeLi });
+          toggleList(editor, { ...options, typeList });
         }
         return;
       }

--- a/packages/slate-plugins/src/marks/components/ToolbarMark.tsx
+++ b/packages/slate-plugins/src/marks/components/ToolbarMark.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ToolbarButton } from 'common';
-import { ToolbarFormatProps } from 'common/types';
+import { ToolbarBlockProps } from 'common/types';
 import { useSlate } from 'slate-react';
 import { isMarkActive } from '../queries';
 import { clearMark, toggleMark } from '../transforms';
@@ -8,23 +8,19 @@ import { clearMark, toggleMark } from '../transforms';
 /**
  * Toolbar button to toggle mark.
  */
-export const ToolbarMark = ({
-  format,
-  clear,
-  ...props
-}: ToolbarFormatProps) => {
+export const ToolbarMark = ({ type, clear, ...props }: ToolbarBlockProps) => {
   const editor = useSlate();
 
   return (
     <ToolbarButton
       {...props}
-      active={isMarkActive(editor, format)}
+      active={isMarkActive(editor, type)}
       onMouseDown={(event: Event) => {
         event.preventDefault();
         if (clear) {
           clearMark(editor, clear);
         }
-        toggleMark(editor, format);
+        toggleMark(editor, type);
       }}
     />
   );

--- a/stories/basic/editable-voids/renderElementEditableVoid.ts
+++ b/stories/basic/editable-voids/renderElementEditableVoid.ts
@@ -1,8 +1,12 @@
-import { getRenderElement } from 'slate-plugins-next/src';
+import { getRenderElement, RenderElementOptions } from 'slate-plugins-next/src';
 import { EditableVoidElement } from './EditableVoidElement';
 import { EDITABLE_VOID } from './types';
 
-export const renderElementEditableVoid = getRenderElement({
-  type: EDITABLE_VOID,
-  component: EditableVoidElement,
-});
+export const renderElementEditableVoid = ({
+  typeEditableVoid = EDITABLE_VOID,
+  component = EditableVoidElement,
+}: RenderElementOptions & { typeEditableVoid?: string } = {}) =>
+  getRenderElement({
+    type: typeEditableVoid,
+    component,
+  });

--- a/stories/basic/hovering-toolbar.stories.tsx
+++ b/stories/basic/hovering-toolbar.stories.tsx
@@ -35,14 +35,14 @@ export const Example = () => {
     <Slate
       editor={editor}
       value={value}
-      onChange={newValue => setValue(newValue)}
+      onChange={(newValue) => setValue(newValue)}
     >
       <HoveringToolbar>
-        <ToolbarMark reversed format={MARK_BOLD} icon={<FormatBold />} />
-        <ToolbarMark reversed format={MARK_ITALIC} icon={<FormatItalic />} />
+        <ToolbarMark reversed type={MARK_BOLD} icon={<FormatBold />} />
+        <ToolbarMark reversed type={MARK_ITALIC} icon={<FormatItalic />} />
         <ToolbarMark
           reversed
-          format={MARK_UNDERLINE}
+          type={MARK_UNDERLINE}
           icon={<FormatUnderlined />}
         />
       </HoveringToolbar>

--- a/stories/basic/huge-document.stories.tsx
+++ b/stories/basic/huge-document.stories.tsx
@@ -6,13 +6,13 @@ import {
   EditablePlugins,
   HeadingPlugin,
 } from '../../packages/slate-plugins/src';
-import { initialValueHugeDocument } from '../config/initialValues';
+import { initialValueHugeDocument, nodeTypes } from '../config/initialValues';
 
 export default {
   title: 'Basic/Huge Document',
 };
 
-const plugins = [HeadingPlugin()];
+const plugins = [HeadingPlugin(nodeTypes)];
 
 export const Example = () => {
   const [value, setValue] = useState(initialValueHugeDocument);
@@ -23,7 +23,7 @@ export const Example = () => {
     <Slate
       editor={editor}
       value={value}
-      onChange={newValue => setValue(newValue)}
+      onChange={(newValue) => setValue(newValue)}
     >
       <EditablePlugins plugins={plugins} spellCheck autoFocus />
     </Slate>

--- a/stories/config/initialValues.ts
+++ b/stories/config/initialValues.ts
@@ -3,6 +3,7 @@ import { Node } from 'slate';
 import {
   ACTION_ITEM,
   BLOCKQUOTE,
+  CODE,
   HeadingType,
   IMAGE,
   LINK,
@@ -11,12 +12,14 @@ import {
   PARAGRAPH,
   TableType,
   VIDEO,
-} from 'slate-plugins-next/src';
+} from '../../packages/slate-plugins/src';
+import { EDITABLE_VOID } from '../basic/editable-voids/types';
 
 export const nodeTypes = {
   typeP: PARAGRAPH,
   typeMention: MENTION,
   typeBlockquote: BLOCKQUOTE,
+  typeCode: CODE,
   typeLink: LINK,
   typeImg: IMAGE,
   typeVideo: VIDEO,
@@ -33,6 +36,7 @@ export const nodeTypes = {
   typeH4: HeadingType.H4,
   typeH5: HeadingType.H5,
   typeH6: HeadingType.H6,
+  typeEditableVoid: EDITABLE_VOID,
 };
 
 export const initialValueVoids: Node[] = [
@@ -46,7 +50,7 @@ export const initialValueVoids: Node[] = [
     ],
   },
   {
-    type: 'editable-void',
+    type: nodeTypes.typeEditableVoid,
     children: [{ text: '' }],
   },
   {
@@ -116,7 +120,7 @@ export const initialValueEmbeds: Node[] = [
     ],
   },
   {
-    type: 'video',
+    type: nodeTypes.typeVideo,
     url: 'https://player.vimeo.com/video/26689853',
     children: [{ text: '' }],
   },
@@ -199,7 +203,7 @@ export const initialValueImages: Node[] = [
     ],
   },
   {
-    type: 'image',
+    type: nodeTypes.typeImg,
     url: 'https://source.unsplash.com/kFrdX5IeQzI',
     children: [{ text: '' }],
   },
@@ -222,7 +226,7 @@ export const initialValueLinks: Node[] = [
         text: 'In addition to block nodes, you can create inline nodes, like ',
       },
       {
-        type: 'link',
+        type: nodeTypes.typeLink,
         url: 'https://en.wikipedia.org/wiki/Hypertext',
         children: [{ text: 'hyperlinks' }],
       },

--- a/stories/config/initialValues.ts
+++ b/stories/config/initialValues.ts
@@ -4,14 +4,40 @@ import {
   ACTION_ITEM,
   BLOCKQUOTE,
   HeadingType,
+  IMAGE,
+  LINK,
+  ListType,
   MENTION,
   PARAGRAPH,
   TableType,
+  VIDEO,
 } from 'slate-plugins-next/src';
+
+export const nodeTypes = {
+  typeP: PARAGRAPH,
+  typeMention: MENTION,
+  typeBlockquote: BLOCKQUOTE,
+  typeLink: LINK,
+  typeImg: IMAGE,
+  typeVideo: VIDEO,
+  typeActionItem: ACTION_ITEM,
+  typeTable: TableType.TABLE,
+  typeTr: TableType.ROW,
+  typeTd: TableType.CELL,
+  typeUl: ListType.UL,
+  typeOl: ListType.OL,
+  typeLi: ListType.LI,
+  typeH1: HeadingType.H1,
+  typeH2: HeadingType.H2,
+  typeH3: HeadingType.H3,
+  typeH4: HeadingType.H4,
+  typeH5: HeadingType.H5,
+  typeH6: HeadingType.H6,
+};
 
 export const initialValueVoids: Node[] = [
   {
-    type: 'paragraph',
+    type: nodeTypes.typeP,
     children: [
       {
         text:
@@ -24,7 +50,7 @@ export const initialValueVoids: Node[] = [
     children: [{ text: '' }],
   },
   {
-    type: 'paragraph',
+    type: nodeTypes.typeP,
     children: [
       {
         text: '',
@@ -35,7 +61,7 @@ export const initialValueVoids: Node[] = [
 
 export const initialValueActionItem: Node[] = [
   {
-    type: PARAGRAPH,
+    type: nodeTypes.typeP,
     children: [
       {
         text:
@@ -44,44 +70,44 @@ export const initialValueActionItem: Node[] = [
     ],
   },
   {
-    type: ACTION_ITEM,
+    type: nodeTypes.typeActionItem,
     checked: true,
     children: [{ text: 'Slide to the left.' }],
   },
   {
-    type: ACTION_ITEM,
+    type: nodeTypes.typeActionItem,
     checked: true,
     children: [{ text: 'Slide to the right.' }],
   },
   {
-    type: ACTION_ITEM,
+    type: nodeTypes.typeActionItem,
     checked: false,
     children: [{ text: 'Criss-cross.' }],
   },
   {
-    type: ACTION_ITEM,
+    type: nodeTypes.typeActionItem,
     checked: true,
     children: [{ text: 'Criss-cross!' }],
   },
   {
-    type: ACTION_ITEM,
+    type: nodeTypes.typeActionItem,
     checked: false,
     children: [{ text: 'Cha cha real smooth…' }],
   },
   {
-    type: ACTION_ITEM,
+    type: nodeTypes.typeActionItem,
     checked: false,
     children: [{ text: "Let's go to work!" }],
   },
   {
-    type: PARAGRAPH,
+    type: nodeTypes.typeP,
     children: [{ text: 'Try it out for yourself!' }],
   },
 ];
 
 export const initialValueEmbeds: Node[] = [
   {
-    type: PARAGRAPH,
+    type: nodeTypes.typeP,
     children: [
       {
         text:
@@ -95,7 +121,7 @@ export const initialValueEmbeds: Node[] = [
     children: [{ text: '' }],
   },
   {
-    type: PARAGRAPH,
+    type: nodeTypes.typeP,
     children: [
       {
         text:
@@ -107,11 +133,11 @@ export const initialValueEmbeds: Node[] = [
 
 export const initialValueForcedLayout: Node[] = [
   {
-    type: HeadingType.H1,
+    type: nodeTypes.typeH1,
     children: [{ text: 'Enforce Your Layout!' }],
   },
   {
-    type: PARAGRAPH,
+    type: nodeTypes.typeP,
     children: [
       {
         text:
@@ -123,7 +149,7 @@ export const initialValueForcedLayout: Node[] = [
 
 export const initialValueHoveringToolbar: Node[] = [
   {
-    type: PARAGRAPH,
+    type: nodeTypes.typeP,
     children: [
       {
         text:
@@ -136,7 +162,7 @@ export const initialValueHoveringToolbar: Node[] = [
     ],
   },
   {
-    type: PARAGRAPH,
+    type: nodeTypes.typeP,
     children: [
       { text: 'Try it out yourself! Just ' },
       { text: 'select any piece of text and the menu will appear', bold: true },
@@ -151,7 +177,7 @@ export const initialValueHugeDocument: Node[] = [];
 
 for (let h = 0; h < HEADINGS; h++) {
   initialValueHugeDocument.push({
-    type: HeadingType.H1,
+    type: nodeTypes.typeH1,
     children: [{ text: faker.lorem.sentence() }],
   });
 
@@ -164,7 +190,7 @@ for (let h = 0; h < HEADINGS; h++) {
 
 export const initialValueImages: Node[] = [
   {
-    type: PARAGRAPH,
+    type: nodeTypes.typeP,
     children: [
       {
         text:
@@ -178,7 +204,7 @@ export const initialValueImages: Node[] = [
     children: [{ text: '' }],
   },
   {
-    type: PARAGRAPH,
+    type: nodeTypes.typeP,
     children: [
       {
         text:
@@ -190,7 +216,7 @@ export const initialValueImages: Node[] = [
 
 export const initialValueLinks: Node[] = [
   {
-    type: PARAGRAPH,
+    type: nodeTypes.typeP,
     children: [
       {
         text: 'In addition to block nodes, you can create inline nodes, like ',
@@ -206,7 +232,7 @@ export const initialValueLinks: Node[] = [
     ],
   },
   {
-    type: PARAGRAPH,
+    type: nodeTypes.typeP,
     children: [
       {
         text:
@@ -218,7 +244,7 @@ export const initialValueLinks: Node[] = [
 
 export const initialValueMarkdownPreview: Node[] = [
   {
-    type: PARAGRAPH,
+    type: nodeTypes.typeP,
     children: [
       {
         text:
@@ -227,18 +253,18 @@ export const initialValueMarkdownPreview: Node[] = [
     ],
   },
   {
-    type: PARAGRAPH,
+    type: nodeTypes.typeP,
     children: [{ text: '## Try it out!' }],
   },
   {
-    type: PARAGRAPH,
+    type: nodeTypes.typeP,
     children: [{ text: 'Try it out for yourself!' }],
   },
 ];
 
 export const initialValueMarkdownShortcuts: Node[] = [
   {
-    type: PARAGRAPH,
+    type: nodeTypes.typeP,
     children: [
       {
         text:
@@ -251,7 +277,7 @@ export const initialValueMarkdownShortcuts: Node[] = [
     children: [{ text: 'A wise quote.' }],
   },
   {
-    type: PARAGRAPH,
+    type: nodeTypes.typeP,
     children: [
       {
         text:
@@ -260,15 +286,15 @@ export const initialValueMarkdownShortcuts: Node[] = [
     ],
   },
   {
-    type: HeadingType.H2,
+    type: nodeTypes.typeH2,
     children: [{ text: 'Try it out!' }],
   },
   {
-    type: PARAGRAPH,
+    type: nodeTypes.typeP,
     children: [
       {
         text:
-          'Try it out for yourself! Try starting a new line with ">", "-", or "#"s.',
+          'Try it out for yourself! Try starting a new line with ">", "-", "1." or "#"s.',
       },
     ],
   },
@@ -276,7 +302,7 @@ export const initialValueMarkdownShortcuts: Node[] = [
 
 export const initialValueMentions: Node[] = [
   {
-    type: PARAGRAPH,
+    type: nodeTypes.typeP,
     children: [
       {
         text:
@@ -285,17 +311,17 @@ export const initialValueMentions: Node[] = [
     ],
   },
   {
-    type: PARAGRAPH,
+    type: nodeTypes.typeP,
     children: [
       { text: 'Try mentioning characters, like ' },
       {
-        type: MENTION,
+        type: nodeTypes.typeMention,
         character: 'R2-D2',
         children: [{ text: '' }],
       },
       { text: ' or ' },
       {
-        type: MENTION,
+        type: nodeTypes.typeMention,
         character: 'Mace Windu',
         children: [{ text: '' }],
       },
@@ -306,7 +332,7 @@ export const initialValueMentions: Node[] = [
 
 export const initialValuePasteHtml: Node[] = [
   {
-    type: PARAGRAPH,
+    type: nodeTypes.typeP,
     children: [
       {
         text:
@@ -322,11 +348,11 @@ export const initialValuePasteHtml: Node[] = [
     ],
   },
   {
-    type: PARAGRAPH,
+    type: nodeTypes.typeP,
     children: [{ text: 'This is an example of doing exactly that!' }],
   },
   {
-    type: PARAGRAPH,
+    type: nodeTypes.typeP,
     children: [
       {
         text:
@@ -338,7 +364,7 @@ export const initialValuePasteHtml: Node[] = [
 
 export const initialValuePasteMd: Node[] = [
   {
-    type: PARAGRAPH,
+    type: nodeTypes.typeP,
     children: [
       {
         text:
@@ -354,11 +380,11 @@ export const initialValuePasteMd: Node[] = [
     ],
   },
   {
-    type: PARAGRAPH,
+    type: nodeTypes.typeP,
     children: [{ text: 'This is an example of doing exactly that!' }],
   },
   {
-    type: PARAGRAPH,
+    type: nodeTypes.typeP,
     children: [
       {
         text:
@@ -370,7 +396,7 @@ export const initialValuePasteMd: Node[] = [
 
 export const initialValuePlainText: Node[] = [
   {
-    type: PARAGRAPH,
+    type: nodeTypes.typeP,
     children: [
       { text: 'This is editable plain text, just like a <textarea>!' },
     ],
@@ -379,7 +405,7 @@ export const initialValuePlainText: Node[] = [
 
 export const initialValueMark: Node[] = [
   {
-    type: PARAGRAPH,
+    type: nodeTypes.typeP,
     children: [
       { text: 'This is editable ' },
       { text: 'rich', bold: true, underline: true, italic: true },
@@ -394,11 +420,11 @@ export const initialValueMark: Node[] = [
 
 export const initialValueRichText: Node[] = [
   {
-    type: HeadingType.H1,
+    type: nodeTypes.typeH1,
     children: [{ text: 'Welcome' }],
   },
   {
-    type: PARAGRAPH,
+    type: nodeTypes.typeP,
     children: [
       { text: 'This is editable ' },
       { text: 'rich', bold: true },
@@ -410,7 +436,7 @@ export const initialValueRichText: Node[] = [
     ],
   },
   {
-    type: PARAGRAPH,
+    type: nodeTypes.typeP,
     children: [
       {
         text:
@@ -431,7 +457,7 @@ export const initialValueRichText: Node[] = [
 
 export const initialValueSearchHighlighting: Node[] = [
   {
-    type: PARAGRAPH,
+    type: nodeTypes.typeP,
     children: [
       {
         text:
@@ -442,7 +468,7 @@ export const initialValueSearchHighlighting: Node[] = [
     ],
   },
   {
-    type: PARAGRAPH,
+    type: nodeTypes.typeP,
     children: [
       { text: 'Try it out for yourself by typing in the search box above!' },
     ],
@@ -451,7 +477,7 @@ export const initialValueSearchHighlighting: Node[] = [
 
 export const initialValueTables: Node[] = [
   {
-    type: PARAGRAPH,
+    type: nodeTypes.typeP,
     children: [
       {
         text:
@@ -460,67 +486,67 @@ export const initialValueTables: Node[] = [
     ],
   },
   {
-    type: TableType.TABLE,
+    type: nodeTypes.typeTable,
     children: [
       {
-        type: TableType.ROW,
+        type: nodeTypes.typeTr,
         children: [
           {
-            type: TableType.CELL,
+            type: nodeTypes.typeTd,
             children: [{ text: '' }],
           },
           {
-            type: TableType.CELL,
+            type: nodeTypes.typeTd,
             children: [{ text: 'Human', bold: true }],
           },
           {
-            type: TableType.CELL,
+            type: nodeTypes.typeTd,
             children: [{ text: 'Dog', bold: true }],
           },
           {
-            type: TableType.CELL,
+            type: nodeTypes.typeTd,
             children: [{ text: 'Cat', bold: true }],
           },
         ],
       },
       {
-        type: TableType.ROW,
+        type: nodeTypes.typeTr,
         children: [
           {
-            type: TableType.CELL,
+            type: nodeTypes.typeTd,
             children: [{ text: '# of Feet', bold: true }],
           },
           {
-            type: TableType.CELL,
+            type: nodeTypes.typeTd,
             children: [{ text: '2' }],
           },
           {
-            type: TableType.CELL,
+            type: nodeTypes.typeTd,
             children: [{ text: '4' }],
           },
           {
-            type: TableType.CELL,
+            type: nodeTypes.typeTd,
             children: [{ text: '4' }],
           },
         ],
       },
       {
-        type: TableType.ROW,
+        type: nodeTypes.typeTr,
         children: [
           {
-            type: TableType.CELL,
+            type: nodeTypes.typeTd,
             children: [{ text: '# of Lives', bold: true }],
           },
           {
-            type: TableType.CELL,
+            type: nodeTypes.typeTd,
             children: [{ text: '1' }],
           },
           {
-            type: TableType.CELL,
+            type: nodeTypes.typeTd,
             children: [{ text: '1' }],
           },
           {
-            type: TableType.CELL,
+            type: nodeTypes.typeTd,
             children: [{ text: '9' }],
           },
         ],
@@ -528,7 +554,7 @@ export const initialValueTables: Node[] = [
     ],
   },
   {
-    type: PARAGRAPH,
+    type: nodeTypes.typeP,
     children: [
       {
         text:
@@ -540,7 +566,7 @@ export const initialValueTables: Node[] = [
 
 export const initialValueSoftBreak: Node[] = [
   {
-    type: PARAGRAPH,
+    type: nodeTypes.typeP,
     children: [
       {
         text:
@@ -556,7 +582,7 @@ export const initialValueSoftBreak: Node[] = [
     ],
   },
   {
-    type: HeadingType.H2,
+    type: nodeTypes.typeH2,
     children: [
       {
         text: 'This is a normal Heading 2',
@@ -564,7 +590,7 @@ export const initialValueSoftBreak: Node[] = [
     ],
   },
   {
-    type: HeadingType.H2,
+    type: nodeTypes.typeH2,
     children: [
       {
         text: 'This is a Heading 2\nwith a soft break',

--- a/stories/docs/guide.stories.mdx
+++ b/stories/docs/guide.stories.mdx
@@ -107,8 +107,8 @@ Another example without `getRenderElement`:
 ```js
 export const renderElementTable = ({
   Table = TableElement,
-  Row = getElement('tr'),
-  Cell = getElement('td'),
+  Row = getElementComponent('tr'),
+  Cell = getElementComponent('td'),
 }: RenderElementTableOptions = {}) => (props: RenderElementProps) => {
   switch (props.element.type) {
     case TableType.TABLE:

--- a/stories/plugins/action-items.stories.tsx
+++ b/stories/plugins/action-items.stories.tsx
@@ -4,14 +4,13 @@ import { createEditor } from 'slate';
 import { withHistory } from 'slate-history';
 import { Slate, withReact } from 'slate-react';
 import {
-  ACTION_ITEM,
   ActionItemPlugin,
   EditablePlugins,
   renderElementActionItem,
   withBreakEmptyReset,
   withDeleteStartReset,
 } from '../../packages/slate-plugins/src';
-import { initialValueActionItem } from '../config/initialValues';
+import { initialValueActionItem, nodeTypes } from '../config/initialValues';
 
 export default {
   title: 'Plugins/Action Item',
@@ -20,12 +19,14 @@ export default {
 };
 
 const resetOptions = {
-  types: [ACTION_ITEM],
+  ...nodeTypes,
+  types: [nodeTypes.typeActionItem],
 };
 
 export const Example = () => {
   const plugins: any[] = [];
-  if (boolean('ActionItemPlugin', true)) plugins.push(ActionItemPlugin());
+  if (boolean('ActionItemPlugin', true))
+    plugins.push(ActionItemPlugin(nodeTypes));
 
   const createReactEditor = () => () => {
     const [value, setValue] = useState(initialValueActionItem);
@@ -44,7 +45,7 @@ export const Example = () => {
       <Slate
         editor={editor}
         value={value}
-        onChange={newValue => setValue(newValue)}
+        onChange={(newValue) => setValue(newValue)}
       >
         <EditablePlugins
           plugins={plugins}

--- a/stories/plugins/elements.stories.tsx
+++ b/stories/plugins/elements.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { boolean } from '@storybook/addon-knobs';
+import { CodeBlock } from '@styled-icons/boxicons-regular/CodeBlock';
 import {
-  Code,
   FormatListBulleted,
   FormatListNumbered,
   FormatQuote,
@@ -18,9 +18,7 @@ import {
   EditablePlugins,
   HeadingPlugin,
   HeadingToolbar,
-  HeadingType,
   ListPlugin,
-  ListType,
   ParagraphPlugin,
   ToolbarBlock,
   ToolbarCode,
@@ -30,7 +28,7 @@ import {
   withDeleteStartReset,
   withList,
 } from '../../packages/slate-plugins/src';
-import { initialValueRichText } from '../config/initialValues';
+import { initialValueRichText, nodeTypes } from '../config/initialValues';
 
 export default {
   title: 'Plugins/Elements',
@@ -44,27 +42,30 @@ export default {
 };
 
 const resetOptions = {
+  ...nodeTypes,
   types: [BLOCKQUOTE],
 };
 
 export const BlockPlugins = () => {
   const plugins: any[] = [];
-  if (boolean('ParagraphPlugin', true)) plugins.push(ParagraphPlugin());
-  if (boolean('HeadingPlugin', true)) plugins.push(HeadingPlugin());
-  if (boolean('HeadingPlugin', true)) plugins.push(HeadingPlugin());
-  if (boolean('BlockquotePlugin', true)) plugins.push(BlockquotePlugin());
-  if (boolean('ListPlugin', true)) plugins.push(ListPlugin());
-  if (boolean('CodePlugin', true)) plugins.push(CodePlugin());
+  if (boolean('ParagraphPlugin', true))
+    plugins.push(ParagraphPlugin(nodeTypes));
+  if (boolean('HeadingPlugin', true)) plugins.push(HeadingPlugin(nodeTypes));
+  if (boolean('HeadingPlugin', true)) plugins.push(HeadingPlugin(nodeTypes));
+  if (boolean('BlockquotePlugin', true))
+    plugins.push(BlockquotePlugin(nodeTypes));
+  if (boolean('ListPlugin', true)) plugins.push(ListPlugin(nodeTypes));
+  if (boolean('CodePlugin', true)) plugins.push(CodePlugin(nodeTypes));
 
   const createReactEditor = () => () => {
     const [value, setValue] = useState(initialValueRichText);
 
     const editor = useMemo(
       () =>
-        withList(
+        withList(nodeTypes)(
           withBreakEmptyReset(resetOptions)(
             withDeleteStartReset(resetOptions)(
-              withBlock(withHistory(withReact(createEditor())))
+              withBlock(nodeTypes)(withHistory(withReact(createEditor())))
             )
           )
         ),
@@ -75,21 +76,23 @@ export const BlockPlugins = () => {
       <Slate
         editor={editor}
         value={value}
-        onChange={newValue => setValue(newValue)}
+        onChange={(newValue) => setValue(newValue)}
       >
         <HeadingToolbar>
-          <ToolbarBlock format={HeadingType.H1} icon={<LooksOne />} />
-          <ToolbarBlock format={HeadingType.H2} icon={<LooksTwo />} />
+          <ToolbarBlock type={nodeTypes.typeH1} icon={<LooksOne />} />
+          <ToolbarBlock type={nodeTypes.typeH2} icon={<LooksTwo />} />
           <ToolbarList
-            format={ListType.UL_LIST}
+            {...nodeTypes}
+            typeList={nodeTypes.typeUl}
             icon={<FormatListBulleted />}
           />
           <ToolbarList
-            format={ListType.OL_LIST}
+            {...nodeTypes}
+            typeList={nodeTypes.typeOl}
             icon={<FormatListNumbered />}
           />
-          <ToolbarBlock format={BLOCKQUOTE} icon={<FormatQuote />} />
-          <ToolbarCode icon={<Code />} />
+          <ToolbarBlock type={BLOCKQUOTE} icon={<FormatQuote />} />
+          <ToolbarCode {...nodeTypes} icon={<CodeBlock />} />
         </HeadingToolbar>
         <EditablePlugins
           plugins={plugins}

--- a/stories/plugins/elements.stories.tsx
+++ b/stories/plugins/elements.stories.tsx
@@ -91,7 +91,10 @@ export const BlockPlugins = () => {
             typeList={nodeTypes.typeOl}
             icon={<FormatListNumbered />}
           />
-          <ToolbarBlock type={BLOCKQUOTE} icon={<FormatQuote />} />
+          <ToolbarBlock
+            type={nodeTypes.typeBlockquote}
+            icon={<FormatQuote />}
+          />
           <ToolbarCode {...nodeTypes} icon={<CodeBlock />} />
         </HeadingToolbar>
         <EditablePlugins

--- a/stories/plugins/forced-layout.stories.tsx
+++ b/stories/plugins/forced-layout.stories.tsx
@@ -7,20 +7,20 @@ import {
   HeadingPlugin,
   withForcedLayout,
 } from '../../packages/slate-plugins/src';
-import { initialValueForcedLayout } from '../config/initialValues';
+import { initialValueForcedLayout, nodeTypes } from '../config/initialValues';
 
 export default {
   title: 'Plugins/Forced Layout',
 };
 
-const plugins = [HeadingPlugin()];
+const plugins = [HeadingPlugin(nodeTypes)];
 
 export const Example = () => {
   const createReactEditor = () => () => {
     const [value, setValue] = useState(initialValueForcedLayout);
 
     const editor = useMemo(
-      () => withForcedLayout(withHistory(withReact(createEditor()))),
+      () => withForcedLayout(nodeTypes)(withHistory(withReact(createEditor()))),
       []
     );
 
@@ -28,7 +28,7 @@ export const Example = () => {
       <Slate
         editor={editor}
         value={value}
-        onChange={newValue => setValue(newValue)}
+        onChange={(newValue) => setValue(newValue)}
       >
         <EditablePlugins
           plugins={plugins}

--- a/stories/plugins/image.stories.tsx
+++ b/stories/plugins/image.stories.tsx
@@ -12,7 +12,7 @@ import {
   ToolbarImage,
   withImage,
 } from '../../packages/slate-plugins/src';
-import { initialValueImages } from '../config/initialValues';
+import { initialValueImages, nodeTypes } from '../config/initialValues';
 
 export default {
   title: 'Plugins/Image',
@@ -25,13 +25,13 @@ export default {
 
 export const Example = () => {
   const plugins: any[] = [];
-  if (boolean('ImagePlugin', true)) plugins.push(ImagePlugin());
+  if (boolean('ImagePlugin', true)) plugins.push(ImagePlugin(nodeTypes));
 
   const createReactEditor = () => () => {
     const [value, setValue] = useState(initialValueImages);
 
     const editor = useMemo(
-      () => withImage(withHistory(withReact(createEditor()))),
+      () => withImage(nodeTypes)(withHistory(withReact(createEditor()))),
       []
     );
 
@@ -39,10 +39,10 @@ export const Example = () => {
       <Slate
         editor={editor}
         value={value}
-        onChange={newValue => setValue(newValue)}
+        onChange={(newValue) => setValue(newValue)}
       >
         <HeadingToolbar>
-          <ToolbarImage icon={<Image />} />
+          <ToolbarImage {...nodeTypes} icon={<Image />} />
         </HeadingToolbar>
         <EditablePlugins plugins={plugins} placeholder="Enter some text..." />
       </Slate>

--- a/stories/plugins/link.stories.tsx
+++ b/stories/plugins/link.stories.tsx
@@ -12,7 +12,7 @@ import {
   ToolbarLink,
   withLink,
 } from '../../packages/slate-plugins/src';
-import { initialValueLinks } from '../config/initialValues';
+import { initialValueLinks, nodeTypes } from '../config/initialValues';
 
 export default {
   title: 'Plugins/Link',
@@ -25,13 +25,13 @@ export default {
 
 export const Example = () => {
   const plugins: any[] = [];
-  if (boolean('LinkPlugin', true)) plugins.push(LinkPlugin());
+  if (boolean('LinkPlugin', true)) plugins.push(LinkPlugin(nodeTypes));
 
   const createReactEditor = () => () => {
     const [value, setValue] = useState(initialValueLinks);
 
     const editor = useMemo(
-      () => withLink(withHistory(withReact(createEditor()))),
+      () => withLink(nodeTypes)(withHistory(withReact(createEditor()))),
       []
     );
 
@@ -39,10 +39,10 @@ export const Example = () => {
       <Slate
         editor={editor}
         value={value}
-        onChange={newValue => setValue(newValue)}
+        onChange={(newValue) => setValue(newValue)}
       >
         <HeadingToolbar>
-          <ToolbarLink icon={<Link />} />
+          <ToolbarLink {...nodeTypes} icon={<Link />} />
         </HeadingToolbar>
         <EditablePlugins plugins={plugins} placeholder="Enter some text..." />
       </Slate>

--- a/stories/plugins/markdown-preview.stories.tsx
+++ b/stories/plugins/markdown-preview.stories.tsx
@@ -35,7 +35,7 @@ export const Example = () => {
       <Slate
         editor={editor}
         value={value}
-        onChange={newValue => setValue(newValue)}
+        onChange={(newValue) => setValue(newValue)}
       >
         <EditablePlugins
           plugins={plugins}

--- a/stories/plugins/markdown-shortcuts.stories.tsx
+++ b/stories/plugins/markdown-shortcuts.stories.tsx
@@ -15,22 +15,26 @@ import {
   withList,
   withShortcuts,
 } from '../../packages/slate-plugins/src';
-import { initialValueMarkdownShortcuts } from '../config/initialValues';
+import {
+  initialValueMarkdownShortcuts,
+  nodeTypes,
+} from '../config/initialValues';
 
 export default {
   title: 'Plugins/Markdown Shortcuts',
 };
 
 const resetOptions = {
+  ...nodeTypes,
   types: [BLOCKQUOTE],
 };
 
 export const Example = () => {
   const plugins = [
-    BlockquotePlugin(),
-    ListPlugin(),
-    HeadingPlugin(),
-    ParagraphPlugin(),
+    BlockquotePlugin(nodeTypes),
+    ListPlugin(nodeTypes),
+    HeadingPlugin(nodeTypes),
+    ParagraphPlugin(nodeTypes),
   ];
 
   const createReactEditor = () => () => {
@@ -38,10 +42,12 @@ export const Example = () => {
 
     const editor = useMemo(
       () =>
-        withList(
+        withList(nodeTypes)(
           withBreakEmptyReset(resetOptions)(
             withDeleteStartReset(resetOptions)(
-              withShortcuts(withBlock(withHistory(withReact(createEditor()))))
+              withShortcuts(nodeTypes)(
+                withBlock(nodeTypes)(withHistory(withReact(createEditor())))
+              )
             )
           )
         ),
@@ -52,7 +58,7 @@ export const Example = () => {
       <Slate
         editor={editor}
         value={value}
-        onChange={newValue => setValue(newValue)}
+        onChange={(newValue) => setValue(newValue)}
       >
         <EditablePlugins
           plugins={plugins}

--- a/stories/plugins/marks.stories.tsx
+++ b/stories/plugins/marks.stories.tsx
@@ -1,8 +1,8 @@
 import React, { useMemo, useState } from 'react';
 import { boolean } from '@storybook/addon-knobs';
+import { CodeAlt } from '@styled-icons/boxicons-regular/CodeAlt';
 import { Subscript, Superscript } from '@styled-icons/foundation';
 import {
-  Code,
   FormatBold,
   FormatItalic,
   FormatStrikethrough,
@@ -68,24 +68,24 @@ export const MarkPlugins = () => {
         onChange={(newValue) => setValue(newValue)}
       >
         <HeadingToolbar>
-          <ToolbarMark format={MARK_BOLD} icon={<FormatBold />} />
-          <ToolbarMark format={MARK_ITALIC} icon={<FormatItalic />} />
-          <ToolbarMark format={MARK_UNDERLINE} icon={<FormatUnderlined />} />
+          <ToolbarMark type={MARK_BOLD} icon={<FormatBold />} />
+          <ToolbarMark type={MARK_ITALIC} icon={<FormatItalic />} />
+          <ToolbarMark type={MARK_UNDERLINE} icon={<FormatUnderlined />} />
           <ToolbarMark
-            format={MARK_STRIKETHROUGH}
+            type={MARK_STRIKETHROUGH}
             icon={<FormatStrikethrough />}
           />
+          <ToolbarMark type={MARK_CODE} icon={<CodeAlt />} />
           <ToolbarMark
-            format={MARK_SUPERSCRIPT}
+            type={MARK_SUPERSCRIPT}
             clear={MARK_SUBSCRIPT}
             icon={<Superscript />}
           />
           <ToolbarMark
-            format={MARK_SUBSCRIPT}
+            type={MARK_SUBSCRIPT}
             clear={MARK_SUPERSCRIPT}
             icon={<Subscript />}
           />
-          <ToolbarMark format={MARK_CODE} icon={<Code />} />
         </HeadingToolbar>
         <EditablePlugins
           plugins={plugins}

--- a/stories/plugins/mention.stories.tsx
+++ b/stories/plugins/mention.stories.tsx
@@ -12,7 +12,7 @@ import {
   withMention,
 } from '../../packages/slate-plugins/src';
 import { CHARACTERS } from '../config/data';
-import { initialValueMentions } from '../config/initialValues';
+import { initialValueMentions, nodeTypes } from '../config/initialValues';
 
 export default {
   title: 'Plugins/Mention',
@@ -25,14 +25,14 @@ export default {
   },
 };
 
-const plugins = [MentionPlugin()];
+const plugins = [MentionPlugin(nodeTypes)];
 
 export const Example = () => {
   const createReactEditor = () => () => {
     const [value, setValue] = useState(initialValueMentions);
 
     const editor = useMemo(
-      () => withMention(withHistory(withReact(createEditor()))),
+      () => withMention(nodeTypes)(withHistory(withReact(createEditor()))),
       []
     );
 
@@ -47,7 +47,7 @@ export const Example = () => {
       <Slate
         editor={editor}
         value={value}
-        onChange={newValue => {
+        onChange={(newValue) => {
           setValue(newValue);
 
           onChangeMention({

--- a/stories/plugins/paste-html.stories.tsx
+++ b/stories/plugins/paste-html.stories.tsx
@@ -22,7 +22,7 @@ import {
   withPasteHtml,
   withTable,
 } from '../../packages/slate-plugins/src';
-import { initialValuePasteHtml } from '../config/initialValues';
+import { initialValuePasteHtml, nodeTypes } from '../config/initialValues';
 
 export default {
   title: 'Plugins/Paste Html',
@@ -31,18 +31,18 @@ export default {
 
 export const Example = () => {
   const plugins = [
-    BlockquotePlugin(),
+    BlockquotePlugin(nodeTypes),
+    CodePlugin(nodeTypes),
+    HeadingPlugin(nodeTypes),
+    ImagePlugin(nodeTypes),
+    LinkPlugin(nodeTypes),
+    ListPlugin(nodeTypes),
+    ParagraphPlugin(nodeTypes),
+    TablePlugin(nodeTypes),
     BoldPlugin(),
-    CodePlugin(),
-    HeadingPlugin(),
-    ImagePlugin(),
     InlineCodePlugin(),
     ItalicPlugin(),
-    LinkPlugin(),
-    ListPlugin(),
-    ParagraphPlugin(),
     StrikethroughPlugin(),
-    TablePlugin(),
     UnderlinePlugin(),
   ];
 
@@ -51,10 +51,10 @@ export const Example = () => {
 
     const editor = useMemo(
       () =>
-        withTable(
-          withImage(
+        withTable(nodeTypes)(
+          withImage(nodeTypes)(
             withPasteHtml(plugins)(
-              withLink(withHistory(withReact(createEditor())))
+              withLink(nodeTypes)(withHistory(withReact(createEditor())))
             )
           )
         ),
@@ -65,7 +65,7 @@ export const Example = () => {
       <Slate
         editor={editor}
         value={value}
-        onChange={newValue => setValue(newValue)}
+        onChange={(newValue) => setValue(newValue)}
       >
         <EditablePlugins
           plugins={plugins}

--- a/stories/plugins/paste-md.stories.tsx
+++ b/stories/plugins/paste-md.stories.tsx
@@ -22,7 +22,7 @@ import {
   withPasteMd,
   withTable,
 } from '../../packages/slate-plugins/src';
-import { initialValuePasteMd } from '../config/initialValues';
+import { initialValuePasteMd, nodeTypes } from '../config/initialValues';
 
 export default {
   title: 'Plugins/Paste Markdown',
@@ -31,18 +31,18 @@ export default {
 
 export const Example = () => {
   const plugins = [
-    BlockquotePlugin(),
+    BlockquotePlugin(nodeTypes),
+    CodePlugin(nodeTypes),
+    HeadingPlugin(nodeTypes),
+    ImagePlugin(nodeTypes),
+    LinkPlugin(nodeTypes),
+    ListPlugin(nodeTypes),
+    ParagraphPlugin(nodeTypes),
+    TablePlugin(nodeTypes),
     BoldPlugin(),
-    CodePlugin(),
-    HeadingPlugin(),
-    ImagePlugin(),
     InlineCodePlugin(),
     ItalicPlugin(),
-    LinkPlugin(),
-    ListPlugin(),
-    ParagraphPlugin(),
     StrikethroughPlugin(),
-    TablePlugin(),
     UnderlinePlugin(),
   ];
 
@@ -51,10 +51,10 @@ export const Example = () => {
 
     const editor = useMemo(
       () =>
-        withTable(
-          withImage(
+        withTable(nodeTypes)(
+          withImage(nodeTypes)(
             withPasteMd(plugins)(
-              withLink(withHistory(withReact(createEditor())))
+              withLink(nodeTypes)(withHistory(withReact(createEditor())))
             )
           )
         ),
@@ -65,7 +65,7 @@ export const Example = () => {
       <Slate
         editor={editor}
         value={value}
-        onChange={newValue => setValue(newValue)}
+        onChange={(newValue) => setValue(newValue)}
       >
         <EditablePlugins
           plugins={plugins}

--- a/stories/plugins/playground.stories.tsx
+++ b/stories/plugins/playground.stories.tsx
@@ -35,7 +35,6 @@ import {
   ItalicPlugin,
   LinkPlugin,
   ListPlugin,
-  ListType,
   MARK_BOLD,
   MARK_CODE,
   MARK_ITALIC,
@@ -231,12 +230,12 @@ export const Plugins = () => {
           <ToolbarLink {...nodeTypes} icon={<Link />} />
           <ToolbarList
             {...nodeTypes}
-            typeList={ListType.UL}
+            typeList={nodeTypes.typeUl}
             icon={<FormatListBulleted />}
           />
           <ToolbarList
             {...nodeTypes}
-            typeList={ListType.OL}
+            typeList={nodeTypes.typeOl}
             icon={<FormatListNumbered />}
           />
           <ToolbarBlock

--- a/stories/plugins/playground.stories.tsx
+++ b/stories/plugins/playground.stories.tsx
@@ -1,8 +1,9 @@
 import React, { useMemo, useState } from 'react';
 import { boolean } from '@storybook/addon-knobs';
+import { CodeAlt } from '@styled-icons/boxicons-regular/CodeAlt';
+import { CodeBlock } from '@styled-icons/boxicons-regular/CodeBlock';
 import { Subscript, Superscript } from '@styled-icons/foundation';
 import {
-  Code,
   FormatBold,
   FormatItalic,
   FormatListBulleted,
@@ -20,16 +21,14 @@ import { createEditor } from 'slate';
 import { withHistory } from 'slate-history';
 import { Slate, withReact } from 'slate-react';
 import {
-  ACTION_ITEM,
   ActionItemPlugin,
-  BLOCKQUOTE,
   BlockquotePlugin,
   BoldPlugin,
+  CodePlugin,
   decorateSearchHighlight,
   EditablePlugins,
   HeadingPlugin,
   HeadingToolbar,
-  HeadingType,
   HoveringToolbar,
   ImagePlugin,
   InlineCodePlugin,
@@ -55,6 +54,7 @@ import {
   SuperscriptPlugin,
   TablePlugin,
   ToolbarBlock,
+  ToolbarCode,
   ToolbarImage,
   ToolbarLink,
   ToolbarList,
@@ -73,7 +73,6 @@ import {
   withPasteHtml,
   withShortcuts,
   withTable,
-  withVideo,
   withVoid,
 } from '../../packages/slate-plugins/src';
 import { EditableVoidPlugin } from '../basic/editable-voids/EditableVoidPlugin';
@@ -86,6 +85,7 @@ import {
   initialValueMentions,
   initialValueRichText,
   initialValueVoids,
+  nodeTypes,
 } from '../config/initialValues';
 
 export default {
@@ -102,28 +102,33 @@ const initialValue = [
 ];
 
 const resetOptions = {
-  types: [ACTION_ITEM, BLOCKQUOTE],
+  ...nodeTypes,
+  types: [nodeTypes.typeActionItem, nodeTypes.typeBlockquote],
 };
 
 export const Plugins = () => {
   const plugins: any[] = [];
 
-  if (boolean('BlockquotePlugin', true)) plugins.push(BlockquotePlugin());
+  if (boolean('BlockquotePlugin', true))
+    plugins.push(BlockquotePlugin(nodeTypes));
+  if (boolean('ActionItemPlugin', true))
+    plugins.push(ActionItemPlugin(nodeTypes));
+  if (boolean('HeadingPlugin', true)) plugins.push(HeadingPlugin(nodeTypes));
+  if (boolean('ImagePlugin', true)) plugins.push(ImagePlugin(nodeTypes));
+  if (boolean('LinkPlugin', true)) plugins.push(LinkPlugin(nodeTypes));
+  if (boolean('ListPlugin', true)) plugins.push(ListPlugin(nodeTypes));
+  if (boolean('MentionPlugin', true)) plugins.push(MentionPlugin(nodeTypes));
+  if (boolean('ParagraphPlugin', true))
+    plugins.push(ParagraphPlugin(nodeTypes));
+  if (boolean('TablePlugin', true)) plugins.push(TablePlugin(nodeTypes));
+  if (boolean('VideoPlugin', true)) plugins.push(VideoPlugin(nodeTypes));
+  if (boolean('CodePlugin', true)) plugins.push(CodePlugin(nodeTypes));
   if (boolean('BoldPlugin', true)) plugins.push(BoldPlugin());
-  if (boolean('ActionItemPlugin', true)) plugins.push(ActionItemPlugin());
-  if (boolean('HeadingPlugin', true)) plugins.push(HeadingPlugin());
-  if (boolean('ImagePlugin', true)) plugins.push(ImagePlugin());
   if (boolean('InlineCodePlugin', true)) plugins.push(InlineCodePlugin());
   if (boolean('ItalicPlugin', true)) plugins.push(ItalicPlugin());
-  if (boolean('LinkPlugin', true)) plugins.push(LinkPlugin());
-  if (boolean('ListPlugin', true)) plugins.push(ListPlugin());
-  if (boolean('MentionPlugin', true)) plugins.push(MentionPlugin());
-  if (boolean('ParagraphPlugin', true)) plugins.push(ParagraphPlugin());
   if (boolean('SearchHighlightPlugin', true))
     plugins.push(SearchHighlightPlugin());
-  if (boolean('TablePlugin', true)) plugins.push(TablePlugin());
   if (boolean('UnderlinePlugin', true)) plugins.push(UnderlinePlugin());
-  if (boolean('VideoPlugin', true)) plugins.push(VideoPlugin());
   if (boolean('SoftBreakPlugin', true)) plugins.push(SoftBreakPlugin());
   if (boolean('SubscriptPlugin', true)) plugins.push(SubscriptPlugin());
   if (boolean('SuperscriptPlugin', true)) plugins.push(SuperscriptPlugin());
@@ -137,18 +142,18 @@ export const Plugins = () => {
 
     const editor = useMemo(
       () =>
-        withVoid([EDITABLE_VOID])(
-          withShortcuts(
-            withVideo(
-              withList(
-                withBreakEmptyReset(resetOptions)(
-                  withDeleteStartReset(resetOptions)(
-                    withBlock(
-                      withMention(
-                        withImage(
-                          withPasteHtml(plugins)(
-                            withLink(
-                              withTable(withHistory(withReact(createEditor())))
+        withVoid([EDITABLE_VOID, nodeTypes.typeVideo])(
+          withShortcuts(nodeTypes)(
+            withList(nodeTypes)(
+              withBreakEmptyReset(resetOptions)(
+                withDeleteStartReset(resetOptions)(
+                  withBlock(nodeTypes)(
+                    withMention(nodeTypes)(
+                      withImage(nodeTypes)(
+                        withPasteHtml(plugins)(
+                          withLink(nodeTypes)(
+                            withTable(nodeTypes)(
+                              withHistory(withReact(createEditor()))
                             )
                           )
                         )
@@ -203,44 +208,50 @@ export const Plugins = () => {
       >
         <ToolbarSearchHighlight icon={Search} setSearch={setSearchHighlight} />
         <HeadingToolbar>
-          <ToolbarBlock format={HeadingType.H1} icon={<LooksOne />} />
-          <ToolbarBlock format={HeadingType.H2} icon={<LooksTwo />} />
-          <ToolbarMark format={MARK_BOLD} icon={<FormatBold />} />
-          <ToolbarMark format={MARK_ITALIC} icon={<FormatItalic />} />
-          <ToolbarMark format={MARK_UNDERLINE} icon={<FormatUnderlined />} />
+          <ToolbarBlock type={nodeTypes.typeH1} icon={<LooksOne />} />
+          <ToolbarBlock type={nodeTypes.typeH2} icon={<LooksTwo />} />
+          <ToolbarMark type={MARK_BOLD} icon={<FormatBold />} />
+          <ToolbarMark type={MARK_ITALIC} icon={<FormatItalic />} />
+          <ToolbarMark type={MARK_UNDERLINE} icon={<FormatUnderlined />} />
           <ToolbarMark
-            format={MARK_STRIKETHROUGH}
+            type={MARK_STRIKETHROUGH}
             icon={<FormatStrikethrough />}
           />
+          <ToolbarMark type={MARK_CODE} icon={<CodeAlt />} />
           <ToolbarMark
-            format={MARK_SUPERSCRIPT}
+            type={MARK_SUPERSCRIPT}
             clear={MARK_SUBSCRIPT}
             icon={<Superscript />}
           />
           <ToolbarMark
-            format={MARK_SUBSCRIPT}
+            type={MARK_SUBSCRIPT}
             clear={MARK_SUPERSCRIPT}
             icon={<Subscript />}
           />
-          <ToolbarMark format={MARK_CODE} icon={<Code />} />
+          <ToolbarLink {...nodeTypes} icon={<Link />} />
           <ToolbarList
-            format={ListType.UL_LIST}
+            {...nodeTypes}
+            typeList={ListType.UL}
             icon={<FormatListBulleted />}
           />
           <ToolbarList
-            format={ListType.OL_LIST}
+            {...nodeTypes}
+            typeList={ListType.OL}
             icon={<FormatListNumbered />}
           />
-          <ToolbarLink icon={<Link />} />
-          <ToolbarImage icon={<Image />} />
-          <ToolbarBlock format={BLOCKQUOTE} icon={<FormatQuote />} />
+          <ToolbarBlock
+            type={nodeTypes.typeBlockquote}
+            icon={<FormatQuote />}
+          />
+          <ToolbarCode {...nodeTypes} icon={<CodeBlock />} />
+          <ToolbarImage {...nodeTypes} icon={<Image />} />
         </HeadingToolbar>
         <HoveringToolbar>
-          <ToolbarMark reversed format={MARK_BOLD} icon={<FormatBold />} />
-          <ToolbarMark reversed format={MARK_ITALIC} icon={<FormatItalic />} />
+          <ToolbarMark reversed type={MARK_BOLD} icon={<FormatBold />} />
+          <ToolbarMark reversed type={MARK_ITALIC} icon={<FormatItalic />} />
           <ToolbarMark
             reversed
-            format={MARK_UNDERLINE}
+            type={MARK_UNDERLINE}
             icon={<FormatUnderlined />}
           />
         </HoveringToolbar>

--- a/stories/plugins/search-highlight.stories.tsx
+++ b/stories/plugins/search-highlight.stories.tsx
@@ -45,7 +45,7 @@ export const Example = () => {
       <Slate
         editor={editor}
         value={value}
-        onChange={newValue => setValue(newValue)}
+        onChange={(newValue) => setValue(newValue)}
       >
         <ToolbarSearchHighlight icon={Search} setSearch={setSearch} />
         <EditablePlugins plugins={plugins} decorate={decorate} />

--- a/stories/plugins/soft-break.stories.tsx
+++ b/stories/plugins/soft-break.stories.tsx
@@ -10,7 +10,6 @@ import {
   EditablePlugins,
   HeadingPlugin,
   HeadingToolbar,
-  HeadingType,
   InlineCodePlugin,
   ParagraphPlugin,
   SoftBreakPlugin,
@@ -21,7 +20,7 @@ import {
   withDeleteStartReset,
   withList,
 } from '../../packages/slate-plugins/src';
-import { initialValueSoftBreak } from '../config/initialValues';
+import { initialValueSoftBreak, nodeTypes } from '../config/initialValues';
 
 export default {
   title: 'Plugins/Soft Break',
@@ -29,17 +28,18 @@ export default {
 };
 
 const resetOptions = {
+  ...nodeTypes,
   types: [BLOCKQUOTE],
 };
 
 export const BlockPlugins = () => {
   const plugins: any[] = [
+    ParagraphPlugin(nodeTypes),
+    HeadingPlugin(nodeTypes),
+    BlockquotePlugin(nodeTypes),
+    CodePlugin(nodeTypes),
     SoftBreakPlugin(),
     InlineCodePlugin(),
-    ParagraphPlugin(),
-    HeadingPlugin(),
-    BlockquotePlugin(),
-    CodePlugin(),
   ];
 
   const createReactEditor = () => () => {
@@ -47,10 +47,10 @@ export const BlockPlugins = () => {
 
     const editor = useMemo(
       () =>
-        withList(
+        withList(nodeTypes)(
           withBreakEmptyReset(resetOptions)(
             withDeleteStartReset(resetOptions)(
-              withBlock(withHistory(withReact(createEditor())))
+              withBlock(nodeTypes)(withHistory(withReact(createEditor())))
             )
           )
         ),
@@ -61,13 +61,16 @@ export const BlockPlugins = () => {
       <Slate
         editor={editor}
         value={value}
-        onChange={newValue => setValue(newValue)}
+        onChange={(newValue) => setValue(newValue)}
       >
         <HeadingToolbar>
-          <ToolbarBlock format={HeadingType.H1} icon={<LooksOne />} />
-          <ToolbarBlock format={HeadingType.H2} icon={<LooksTwo />} />
-          <ToolbarBlock format={BLOCKQUOTE} icon={<FormatQuote />} />
-          <ToolbarCode icon={<Code />} />
+          <ToolbarBlock type={nodeTypes.typeH1} icon={<LooksOne />} />
+          <ToolbarBlock type={nodeTypes.typeH2} icon={<LooksTwo />} />
+          <ToolbarBlock
+            type={nodeTypes.typeBlockquote}
+            icon={<FormatQuote />}
+          />
+          <ToolbarCode {...nodeTypes} icon={<Code />} />
         </HeadingToolbar>
         <EditablePlugins
           plugins={plugins}

--- a/stories/plugins/tables.stories.tsx
+++ b/stories/plugins/tables.stories.tsx
@@ -29,7 +29,7 @@ import {
   ToolbarTable,
   withTable,
 } from '../../packages/slate-plugins/src';
-import { initialValueTables } from '../config/initialValues';
+import { initialValueTables, nodeTypes } from '../config/initialValues';
 
 export default {
   title: 'Plugins/Table',
@@ -39,13 +39,13 @@ export default {
 
 export const Example = () => {
   const plugins = [BoldPlugin()];
-  if (boolean('TablePlugin', true)) plugins.push(TablePlugin());
+  if (boolean('TablePlugin', true)) plugins.push(TablePlugin(nodeTypes));
 
   const createReactEditor = () => () => {
     const [value, setValue] = useState(initialValueTables);
 
     const editor = useMemo(
-      () => withTable(withHistory(withReact(createEditor()))),
+      () => withTable(nodeTypes)(withHistory(withReact(createEditor()))),
       []
     );
 
@@ -53,16 +53,40 @@ export const Example = () => {
       <Slate
         editor={editor}
         value={value}
-        onChange={newValue => setValue(newValue)}
+        onChange={(newValue) => setValue(newValue)}
       >
         <HeadingToolbar>
-          <ToolbarMark format={MARK_BOLD} icon={<FormatBold />} />
-          <ToolbarTable action={insertTable} icon={<BorderAll />} />
-          <ToolbarTable action={deleteTable} icon={<BorderClear />} />
-          <ToolbarTable action={addRow} icon={<BorderBottom />} />
-          <ToolbarTable action={deleteRow} icon={<BorderTop />} />
-          <ToolbarTable action={addColumn} icon={<BorderLeft />} />
-          <ToolbarTable action={deleteColumn} icon={<BorderRight />} />
+          <ToolbarMark type={MARK_BOLD} icon={<FormatBold />} />
+          <ToolbarTable
+            {...nodeTypes}
+            action={insertTable}
+            icon={<BorderAll />}
+          />
+          <ToolbarTable
+            {...nodeTypes}
+            action={deleteTable}
+            icon={<BorderClear />}
+          />
+          <ToolbarTable
+            {...nodeTypes}
+            action={addRow}
+            icon={<BorderBottom />}
+          />
+          <ToolbarTable
+            {...nodeTypes}
+            action={deleteRow}
+            icon={<BorderTop />}
+          />
+          <ToolbarTable
+            {...nodeTypes}
+            action={addColumn}
+            icon={<BorderLeft />}
+          />
+          <ToolbarTable
+            {...nodeTypes}
+            action={deleteColumn}
+            icon={<BorderRight />}
+          />
         </HeadingToolbar>
         <EditablePlugins plugins={plugins} />
       </Slate>

--- a/stories/plugins/video.stories.tsx
+++ b/stories/plugins/video.stories.tsx
@@ -6,10 +6,11 @@ import { Slate, withReact } from 'slate-react';
 import {
   EditablePlugins,
   renderElementVideo,
+  VIDEO,
   VideoPlugin,
-  withVideo,
+  withVoid,
 } from '../../packages/slate-plugins/src';
-import { initialValueEmbeds } from '../config/initialValues';
+import { initialValueEmbeds, nodeTypes } from '../config/initialValues';
 
 export default {
   title: 'Plugins/Video',
@@ -21,13 +22,13 @@ export default {
 
 export const Example = () => {
   const plugins: any[] = [];
-  if (boolean('VideoPlugin', true)) plugins.push(VideoPlugin());
+  if (boolean('VideoPlugin', true)) plugins.push(VideoPlugin(nodeTypes));
 
   const createReactEditor = () => () => {
     const [value, setValue] = useState(initialValueEmbeds);
 
     const editor = useMemo(
-      () => withVideo(withHistory(withReact(createEditor()))),
+      () => withVoid([VIDEO])(withHistory(withReact(createEditor()))),
       []
     );
 


### PR DESCRIPTION
### `0.58.0` — April 29, 2020

###### BREAKING

- refactor `getElement` to `getElementComponent`
- refactor elements types to reflect the html tags. 
Also avoiding `-` as it's not valid in GraphQL enums. 
    - `action-item` -> `action_item`
    - `block-quote` -> `blockquote`
    - `heading-one` -> `h1` (until `h6`)
    - `link` -> `a`
    - `numbered-list` -> `ol`
    - `bulleted-list` -> `ul`
    - `list-item` -> `li`
    - `paragraph` -> `p`
    - `table-row` -> `tr`
    - `table-cell` -> `td`

If you already saved elements in your database, you will need to migrate or override the types with the previous ones:

```js
// you can add nodeTypes to any element plugin
export const nodeTypes = {
  typeP: PARAGRAPH,
  typeMention: MENTION,
  typeBlockquote: BLOCKQUOTE,
  typeCode: CODE,
  typeLink: LINK,
  typeImg: IMAGE,
  typeVideo: VIDEO,
  typeActionItem: ACTION_ITEM,
  typeTable: TableType.TABLE,
  typeTr: TableType.ROW,
  typeTd: TableType.CELL,
  typeUl: ListType.UL,
  typeOl: ListType.OL,
  typeLi: ListType.LI,
  typeH1: HeadingType.H1,
  typeH2: HeadingType.H2,
  typeH3: HeadingType.H3,
  typeH4: HeadingType.H4,
  typeH5: HeadingType.H5,
  typeH6: HeadingType.H6,
  typeEditableVoid: EDITABLE_VOID,
};
```

###### NEW

- Ordered lists supported in `withShortcuts` (Markdown Shortcuts) by typing `1.`.
- Option type to all elements. Not yet for the marks.
- `getRenderElements`

cc @horacioh @eivindw 