### PR TITLE
[mentions] change from startsWith to include

### DIFF
--- a/packages/slate-plugins/src/elements/mention/useMention.ts
+++ b/packages/slate-plugins/src/elements/mention/useMention.ts
@@ -12,7 +12,7 @@ export const useMention = ({
   const [index, setIndex] = useState(0);
   const [search, setSearch] = useState('');
   const chars = characters
-    .filter((c) => c.toLowerCase().startsWith(search.toLowerCase()))
+    .filter((c) => c.toLowerCase().includes(search.toLowerCase()))
     .slice(0, maxSuggestions);
 
   return { target, setTarget, index, setIndex, search, setSearch, chars };


### PR DESCRIPTION
fixes #100 

Makes filtering for names in the mention plugin a bit more permissive. With this change substrings can be used instead of only the beginning of the name. 

I noticed that some characters cannot be used e.g. typing `@R2-`, when the user types `-` the suggestion popup gets closed. Will open a separate issue for that.