### PR TITLE
fix(deserializeMd): fix export + separate utils

### DIFF
--- a/packages/slate-plugins/src/deserializers/deserialize-md/index.ts
+++ b/packages/slate-plugins/src/deserializers/deserialize-md/index.ts
@@ -1,1 +1,2 @@
-export * from 'deserializers/deserialize-md/withDeserializeMd';
+export * from './withDeserializeMd';
+export * from './utils'

--- a/packages/slate-plugins/src/deserializers/deserialize-md/utils/filterBreakLines.ts
+++ b/packages/slate-plugins/src/deserializers/deserialize-md/utils/filterBreakLines.ts
@@ -1,0 +1,3 @@
+export function filterBreaklines(item: any): boolean {
+  return !item.text;
+}

--- a/packages/slate-plugins/src/deserializers/deserialize-md/utils/index.ts
+++ b/packages/slate-plugins/src/deserializers/deserialize-md/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './filterBreakLines'

--- a/packages/slate-plugins/src/deserializers/deserialize-md/withDeserializeMd.ts
+++ b/packages/slate-plugins/src/deserializers/deserialize-md/withDeserializeMd.ts
@@ -3,10 +3,7 @@ import { htmlDeserialize } from 'deserializers/deserialize-html';
 import marked from 'marked';
 import { Node, Transforms } from 'slate';
 import { ReactEditor } from 'slate-react';
-
-export function filterBreaklines(item: any): boolean {
-  return !item.text;
-}
+import { filterBreaklines } from './utils';
 
 export const withDeserializeMd = (plugins: SlatePlugin[]) => <
   T extends ReactEditor


### PR DESCRIPTION
Issue: #128 

## What I did

- fix main function export
- separate utils (filterBreakLines) from main plugin
- normalize file structure like `withDeserializeHtml`

## How to test

- Is this testable with Jest? Yes!, will add a test for it!
- Does this need a new example in Storybook? Nop!
- Does this need an update to the documentation? Nop!
