### PR TITLE
add onclick to MentionElement

### DIFF
--- a/packages/slate-plugins/src/elements/mention/MentionPlugin.ts
+++ b/packages/slate-plugins/src/elements/mention/MentionPlugin.ts
@@ -1,10 +1,10 @@
 import { SlatePlugin } from 'common/types';
-import { RenderElementOptions } from 'element';
 import { deserializeMention } from 'elements/mention/deserializeMention';
 import { renderElementMention } from 'elements/mention/renderElementMention';
+import { MentionRenderElementOptions } from './types';
 
 export const MentionPlugin = (
-  options?: RenderElementOptions & { typeMention: string }
+  options?: Partial<MentionRenderElementOptions> & { typeMention: string }
 ): SlatePlugin => ({
   renderElement: renderElementMention(options),
   deserialize: deserializeMention(options),

--- a/packages/slate-plugins/src/elements/mention/components/MentionElement.tsx
+++ b/packages/slate-plugins/src/elements/mention/components/MentionElement.tsx
@@ -1,34 +1,35 @@
 import React from 'react';
 import { useFocused, useSelected } from 'slate-react';
-import { MentionRenderElementProps } from '../types';
+import { MentionableItem, MentionRenderElementProps } from '../types';
 
-export const MentionElement = ({
-  attributes,
-  children,
-  element,
-}: MentionRenderElementProps) => {
-  const selected = useSelected();
-  const focused = useFocused();
+export const getMentionElement = (
+  onClick?: (mentionable: MentionableItem) => void
+) => {
+  return ({ attributes, children, element }: MentionRenderElementProps) => {
+    const selected = useSelected();
+    const focused = useFocused();
 
-  return (
-    <span
-      {...attributes}
-      data-slate-character={element.mentionable.value}
-      contentEditable={false}
-      style={{
-        padding: '3px 3px 2px',
-        margin: '0 1px',
-        verticalAlign: 'baseline',
-        display: 'inline-block',
-        borderRadius: '4px',
-        backgroundColor: '#eee',
-        fontSize: '0.9em',
-        boxShadow: selected && focused ? '0 0 0 2px #B4D5FF' : 'none',
-      }}
-    >
-      {element.prefix}
-      {element.mentionable.value}
-      {children}
-    </span>
-  );
+    return (
+      <span
+        {...attributes}
+        onClick={onClick ? () => onClick(element.mentionable) : undefined}
+        data-slate-character={element.mentionable.value}
+        contentEditable={false}
+        style={{
+          padding: '3px 3px 2px',
+          margin: '0 1px',
+          verticalAlign: 'baseline',
+          display: 'inline-block',
+          borderRadius: '4px',
+          backgroundColor: '#eee',
+          fontSize: '0.9em',
+          boxShadow: selected && focused ? '0 0 0 2px #B4D5FF' : 'none',
+        }}
+      >
+        {element.prefix}
+        {element.mentionable.value}
+        {children}
+      </span>
+    );
+  };
 };

--- a/packages/slate-plugins/src/elements/mention/renderElementMention.ts
+++ b/packages/slate-plugins/src/elements/mention/renderElementMention.ts
@@ -1,12 +1,16 @@
-import { getRenderElement, RenderElementOptions } from 'element';
-import { MentionElement } from './components';
-import { MENTION } from './types';
+import { getRenderElement } from 'element';
+import { getMentionElement } from './components';
+import { MENTION, MentionRenderElementOptions } from './types';
 
-export const renderElementMention = ({
-  typeMention = MENTION,
-  component = MentionElement,
-}: RenderElementOptions = {}) =>
-  getRenderElement({
+export const renderElementMention = (
+  options: Partial<MentionRenderElementOptions> = {}
+) => {
+  const {
+    typeMention = MENTION,
+    component = getMentionElement(options.onClick),
+  } = options;
+  return getRenderElement({
     type: typeMention,
     component,
   });
+};

--- a/packages/slate-plugins/src/elements/mention/types.ts
+++ b/packages/slate-plugins/src/elements/mention/types.ts
@@ -1,3 +1,4 @@
+import { RenderElementOptions } from 'element/types';
 import { Element, Node } from 'slate';
 import { RenderElementProps } from 'slate-react';
 
@@ -31,4 +32,8 @@ export interface MentionNode extends Element {
 
 export interface MentionRenderElementProps extends RenderElementProps {
   element: MentionNode;
+}
+
+export interface MentionRenderElementOptions extends RenderElementOptions {
+  onClick: (mentionable: MentionableItem) => void;
 }

--- a/stories/element/inline-void/mention.stories.tsx
+++ b/stories/element/inline-void/mention.stories.tsx
@@ -23,7 +23,13 @@ export default {
   },
 };
 
-const plugins = [ParagraphPlugin(nodeTypes), MentionPlugin(nodeTypes)];
+const plugins = [
+  ParagraphPlugin(nodeTypes), 
+  MentionPlugin({
+    ...nodeTypes, 
+    onClick: (mentionable) => alert(`Hello, I'm ${mentionable.value}`),
+  })
+];
 
 const withPlugins = [withReact, withHistory, withMention(nodeTypes)] as const;
 


### PR DESCRIPTION
Issue:
Currently there is no way of adding an onclick handler to a MentionElement.

## What I did
fixes #132 . Created a factory function for generating the MentionElement, which makes it possible to pass in directly options to it.

## How to test
Added it to the mentions example in the storybook.


<!--

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->