### PR TITLE
mention: testing, refactoring

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,7 @@
 module.exports = {
   extends: ['@borealisgroup/eslint-config-ts', 'plugin:mdx/recommended'],
   rules: {
+    '@typescript-eslint/interface-name-prefix': 'off',
     '@typescript-eslint/no-namespace': 'off',
     'no-alert': 'off',
     'import/extensions': [

--- a/.storybook/tsconfig.json
+++ b/.storybook/tsconfig.json
@@ -8,5 +8,5 @@
     ]
   },
   "include": ["../packages/slate-plugins/src/**/*"],
-  "exclude": ["**/node_modules/**", "**/dist/**", "**/*test*/**", "**/*spec*/**"]
+  "exclude": ["**/node_modules/**", "**/dist/**", "**/*test*/**", "**/*spec*/**", "**/*template*"]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,10 @@ bumps.
 - `MentionNode` interface: replaced `mentionable` by `value`. You can
   add more fields to the element interface instead of adding them to
   `mentionable`
-
+- `onKeyDownMark`:
+  - signature changed from `({ clear, type, hotkey, }:
+    MarkOnKeyDownOptions)` to `(type: string, hotkey: string, { clear }:
+    MarkOnKeyDownOptions = {})`
 
 ###### NEW
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,52 @@
 # Changelog
 
-This is a list of changes to Slate with each new release. Until 1.0.0 is released, breaking changes will be added as minor or patch version bumps.
+This is a list of changes to Slate with each new release. Until 1.0.0 is
+released, breaking changes will be added as minor or patch version
+bumps.
 
 ---
+
+### `0.58.6` — May 20, 2020
+
+###### BREAKING CHANGE
+
+- `useMention`:
+  - removed `MentionSelectComponent` from return
+- `onChangeMention`:
+  - signature changed from `({ editor }: { editor: Editor })` to
+    `(editor: Editor)`
+- `MentionSelect`:
+  - props renaming:
+    - from `mentionables` to `options`
+    - from `index` to `valueIndex`
+    - from `target` to `at`
+- `MentionNode` interface: replaced `mentionable` by `value`. You can
+  add more fields to the element interface instead of adding them to
+  `mentionable`
+
+
+###### NEW
+
+- `utils`:
+  - `getPreviousIndex`
+  - `getNextIndex`
+- `queries`:
+  - `isPointAtWordEnd`
+  - `isWordAfterTrigger`
+- `useMention`:
+  - `options` is now optional
+- `renderElementMention`:
+  - added `prefix` option
+- `MentionSelect`:
+  - added props:
+    - `styles`, see
+      [Component Styling](https://github.com/microsoft/fluentui/wiki/Component-Styling)
+- `getRenderElement`
+  - added a 3rd argument: `options` that will be passed to the component
+    as props. You should use that for "static" props (same value for all
+    instances). And you should mutate the element when it's variable.
+- `MentionElement`:
+  - attribute `data-slate-character` renamed to `data-slate-value`
 
 ### `0.58.5` — May 19, 2020
 
@@ -53,31 +97,36 @@ useMention(CHARACTERS, {
 ###### BREAKING
 
 - refactored:
-    - `toggleCode` to `toggleWrapNodes` (generic).
+  - `toggleCode` to `toggleWrapNodes` (generic).
 - removed:
-    - `clearMark` in favor of `Editor.removeMark`.
+  - `clearMark` in favor of `Editor.removeMark`.
 
 ###### NEW
 
-- `pipe`: new helper to avoid the wrapper hell when using `withPlugins`. You can now have an array of plugins `withPlugins`.
-- `EditablePlugins`: new props for adding your dependencies to the corresponding `useCallback`.
-    - `decorateDeps`
-    - `renderElementDeps`
-    - `renderLeafDeps`
-    - `onDOMBeforeInputDeps`
-    - `onKeyDownDeps`
-- `toggleMark`: new optional parameter `clear`: marks to clear when adding mark.
+- `pipe`: new helper to avoid the wrapper hell when using `withPlugins`.
+  You can now have an array of plugins `withPlugins`.
+- `EditablePlugins`: new props for adding your dependencies to the
+  corresponding `useCallback`.
+  - `decorateDeps`
+  - `renderElementDeps`
+  - `renderLeafDeps`
+  - `onDOMBeforeInputDeps`
+  - `onKeyDownDeps`
+- `toggleMark`: new optional parameter `clear`: marks to clear when
+  adding mark.
 - helpers:
-    - `createDefaultHandler`
+  - `createDefaultHandler`
 
 ###### IMPROVEMENT
 
-- there was a big performance gap between the official slate `Editable` component and our `EditablePlugins` component. This has been resolved by using `useCallback`.
+- there was a big performance gap between the official slate `Editable`
+  component and our `EditablePlugins` component. This has been resolved
+  by using `useCallback`.
 
 ###### FIX
 
 - `deserializeLink`: should work with slate fragments.
-- `withForcedLayout` was normalizing on each change. 
+- `withForcedLayout` was normalizing on each change.
 
 ### `0.58.2` — May 17, 2020
 
@@ -88,11 +137,14 @@ useMention(CHARACTERS, {
 ###### NEW
 
 - `withNodeID`: new options:
-    - `filterText`
-    - `filter`
-    - `allow`
-    - `exclude`
-- `setPropsToNodes`: helper to set props to nodes and its children (recursively), with many options to filter the nodes that will receive the props (e.g. only Element, only Text, only nodes of type Paragraph, etc.).
+  - `filterText`
+  - `filter`
+  - `allow`
+  - `exclude`
+- `setPropsToNodes`: helper to set props to nodes and its children
+  (recursively), with many options to filter the nodes that will receive
+  the props (e.g. only Element, only Text, only nodes of type Paragraph,
+  etc.).
 
 ###### FIX
 
@@ -103,23 +155,27 @@ useMention(CHARACTERS, {
 ###### BREAKING
 
 - renamed:
-    - `withPasteHtml` to `withDeserializeHtml`
-    - `withPasteMd` to `withDeserializeMd`
-    - `onKeyDownMark.mark` to `onKeyDownMark.type` 
+  - `withPasteHtml` to `withDeserializeHtml`
+  - `withPasteMd` to `withDeserializeMd`
+  - `onKeyDownMark.mark` to `onKeyDownMark.type`
 - refactored:
-    - `onKeyDownMention` and `onChangeMention` are now returned by `useMention`
-    - `isBlockActive` and `isLinkActive` have been removed in favor of `isNodeInSelection`
+  - `onKeyDownMention` and `onChangeMention` are now returned by
+    `useMention`
+  - `isBlockActive` and `isLinkActive` have been removed in favor of
+    `isNodeInSelection`
 
 ###### NEW
 
 - new options for mark plugins: type (`typeBold`, `typeItalic`, etc.) .
-- `withDeserializeHtml`: 
-    - the deserializer is now using `data-slate-type` attribute of each HTML element. So copy/pasting slate fragments should now work.
-    - when pasting a value, the type of the first node will replace the type of the selected node (using `Transforms.setNodes`).
+- `withDeserializeHtml`:
+  - the deserializer is now using `data-slate-type` attribute of each
+    HTML element. So copy/pasting slate fragments should now work.
+  - when pasting a value, the type of the first node will replace the
+    type of the selected node (using `Transforms.setNodes`).
 - `withTransforms`:
-    - extends `editor` with transforms (only one for now).
+  - extends `editor` with transforms (only one for now).
 - `withNodeID`:
-    - Set an id to the new `Element` and/or `Text` nodes.
+  - Set an id to the new `Element` and/or `Text` nodes.
 - `deserializeMention`
 - `deserializeActionItem`
 - `deserializeIframe`
@@ -132,8 +188,11 @@ useMention(CHARACTERS, {
 ###### FIX
 
 - `withDeserializeHtml`: fix `Cannot read property 'children' of null`
-- `withForcedLayout`: the previous behavior was forcing to have paragraph nodes after the title. New behavior: first node should be a title (otherwise insert/edit) and second node should exist (otherwise insert a paragraph by default).
-We will see how to generalize this plugin in a future release.
+- `withForcedLayout`: the previous behavior was forcing to have
+  paragraph nodes after the title. New behavior: first node should be a
+  title (otherwise insert/edit) and second node should exist (otherwise
+  insert a paragraph by default). We will see how to generalize this
+  plugin in a future release.
 - `Toolbar`: change `height` to `min-height` for dynamic height.
 
 ###### IMPROVEMENTS
@@ -141,28 +200,29 @@ We will see how to generalize this plugin in a future release.
 - unit testing
 - a lot of refactoring
 - `HeadingPlugin`:
-    - styling change (from h1 to h6)
+  - styling change (from h1 to h6)
 - `EditablePlugins`:
-    - `style` props is now overridable
+  - `style` props is now overridable
 
 ### `0.58.0` — April 29, 2020
 
 ###### BREAKING
 
 - refactor `getElement` to `getElementComponent`
-- refactor elements types to reflect the html tags. 
-Also avoiding `-` as it's not valid in GraphQL enums. 
-    - `action-item` -> `action_item`
-    - `block-quote` -> `blockquote`
-    - `heading-one` -> `h1` (until `h6`)
-    - `link` -> `a`
-    - `numbered-list` -> `ol`
-    - `bulleted-list` -> `ul`
-    - `list-item` -> `li`
-    - `paragraph` -> `p`
-    - `table-row` -> `tr`
-    - `table-cell` -> `td`
-If you already saved elements in your database, you will need to migrate or override the types with the previous ones:
+- refactor elements types to reflect the html tags. Also avoiding `-` as
+  it's not valid in GraphQL enums.
+  - `action-item` -> `action_item`
+  - `block-quote` -> `blockquote`
+  - `heading-one` -> `h1` (until `h6`)
+  - `link` -> `a`
+  - `numbered-list` -> `ol`
+  - `bulleted-list` -> `ul`
+  - `list-item` -> `li`
+  - `paragraph` -> `p`
+  - `table-row` -> `tr`
+  - `table-cell` -> `td` If you already saved elements in your database,
+    you will need to migrate or override the types with the previous
+    ones:
 
 ```js
 // you can add nodeTypes to any element plugin
@@ -193,7 +253,8 @@ export const nodeTypes = {
 
 ###### NEW
 
-- Ordered lists supported in `withShortcuts` (Markdown Shortcuts) by typing `1.`.
+- Ordered lists supported in `withShortcuts` (Markdown Shortcuts) by
+  typing `1.`.
 - Option type to all elements. Not yet for the marks.
 - `getRenderElements`
 
@@ -202,7 +263,8 @@ export const nodeTypes = {
 ###### NEW
 
 - queries:
-  - `isRangeAtRoot(point: Point)` to check if anchor or focus of a range is at the root.
+  - `isRangeAtRoot(point: Point)` to check if anchor or focus of a range
+    is at the root.
 
 ###### FIX
 
@@ -221,40 +283,47 @@ export const nodeTypes = {
 
 ###### FIX
 
-- `plugin-list`: fixed a bug where toggling the list throws an error when a paragraph has few leafs
+- `plugin-list`: fixed a bug where toggling the list throws an error
+  when a paragraph has few leafs
 
 ### `0.57.13` — April 25, 2020
 
 ###### NEW
 
-- `plugin-marks`: New plugins for HTML `<sub>` and `<sup>` tags: superscript and subscript plugins. Included in the "Marks" story.
+- `plugin-marks`: New plugins for HTML `<sub>` and `<sup>` tags:
+  superscript and subscript plugins. Included in the "Marks" story.
 
 ### `0.57.12` — April 14, 2020
 
 ###### FIX
 
-- Deserializer: pasting html or markdown with Elements inside Text tags works correctly now.
+- Deserializer: pasting html or markdown with Elements inside Text tags
+  works correctly now.
 
 ### `0.57.11` — March 3, 2020
 
 ###### NEW
 
-- `paste-md`: 
-    - markdown can be pasted into the editor
+- `paste-md`:
+  - markdown can be pasted into the editor
 
 ### `0.57.10` — February 25, 2020
 
 ###### FIX
 
 - `plugin-list`:
-    - make sure list item is removed when unwrapping.
-    - if multiple paragraphs are selected when pressing toggle - they should end up as separate list items.
+  - make sure list item is removed when unwrapping.
+  - if multiple paragraphs are selected when pressing toggle - they
+    should end up as separate list items.
 
 ### `0.57.9` — February 25, 2020
 
 ###### FIX
 
-- The default toggleBlock function creates several code blocks if there are multiple paragraphs selected. This fix creates a toggleCode function that just wraps the whole selection in a code block - or unwraps if it is already in a block.
+- The default toggleBlock function creates several code blocks if there
+  are multiple paragraphs selected. This fix creates a toggleCode
+  function that just wraps the whole selection in a code block - or
+  unwraps if it is already in a block.
 
 ### `0.57.8` — February 5, 2020
 
@@ -271,39 +340,48 @@ export const nodeTypes = {
 ###### BREAKING
 
 - `plugin-list`:
-    - Each list item now has a paragraph child.
+  - Each list item now has a paragraph child.
 
 ###### NEW
 
 - `plugin-list`:
-    - Supports nested lists:
-      - Press `Tab` on a list item (except the first one) to indent the current list.
-      - Press `Shift+Tab`, `Enter` or `Backspace` to unindent the current list.
+  - Supports nested lists:
+    - Press `Tab` on a list item (except the first one) to indent the
+      current list.
+    - Press `Shift+Tab`, `Enter` or `Backspace` to unindent the current
+      list.
 
 ### `0.57.6` — January 8, 2020
 
 ###### FIX
 
 - styles:
-    - `line-height` of heading
+  - `line-height` of heading
 
 ### `0.57.5` — January 7, 2020
 
 ###### BREAKING
 
 - plugins:
-    - `withList` has been removed and its logic is now inside `withBlock` with the new option `unwrapTypes`.
-    - `withShortcuts`: removed `deleteBackward` logic as its covered by `withDeleteStartReset`.
-- `p` tag was the default if no `type` was provided. The new default is `div`.
+  - `withList` has been removed and its logic is now inside `withBlock`
+    with the new option `unwrapTypes`.
+  - `withShortcuts`: removed `deleteBackward` logic as its covered by
+    `withDeleteStartReset`.
+- `p` tag was the default if no `type` was provided. The new default is
+  `div`.
 
 ###### NEW
 
 - plugins:
-    - `withDeleteStartReset`: on delete at the start of an empty block in types, replace it with a new paragraph.
-    - `withBreakEmptyReset`: on insert break at the start of an empty block in types, replace it with a new paragraph.
+  - `withDeleteStartReset`: on delete at the start of an empty block in
+    types, replace it with a new paragraph.
+  - `withBreakEmptyReset`: on insert break at the start of an empty
+    block in types, replace it with a new paragraph.
 - queries:
-    - `isList`
+  - `isList`
 - styles
-    - action item.
-    - removed the element styling from `globalStyle` as it is not exported.
-    - a lot of spacing changes.
+  - action item.
+  - removed the element styling from `globalStyle` as it is not
+    exported.
+  - a lot of spacing changes.
+

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
     'src/**/*',
     '!**/*test*/**',
     '!**/*fixture*/**',
+    '!**/*template*/**',
     '!**/*stories*',
     '!**/*.development.*',
   ],

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "useWorkspaces": true,
   "packages": ["packages/*"],
   "version": "independent",
-  "ignoreChanges": ["**test**", "**.spec**", "**/*.md", "**/*stories*"]
+  "ignoreChanges": ["**test**", "**.spec**", "**/*.md", "**/*stories*", "**/*template*"]
 }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "react": "^16.13.1",
     "react-docgen-typescript-loader": "^3.7.2",
     "react-dom": "^16.13.1",
+    "react-test-renderer": "^16.13.1",
     "rollup": "^2.8.0",
     "rollup-plugin-babel": "^4.4.0",
     "rollup-plugin-commonjs": "^10.1.0",

--- a/packages/slate-plugins/package.json
+++ b/packages/slate-plugins/package.json
@@ -27,6 +27,9 @@
     "access": "public"
   },
   "dependencies": {
+    "@uifabric/merge-styles": "^7.14.0",
+    "@uifabric/styling": "^7.12.9",
+    "@uifabric/utilities": "^7.17.3",
     "image-extensions": "^1.1.0",
     "is-hotkey": "^0.1.6",
     "lodash": "^4.17.15",

--- a/packages/slate-plugins/src/__templates__/types-element.template.ts
+++ b/packages/slate-plugins/src/__templates__/types-element.template.ts
@@ -2,11 +2,10 @@ import { RenderElementOptions } from 'element';
 import { Element } from 'slate';
 import { RenderElementProps } from 'slate-react';
 
-export interface TemplateNodeData {
-  [key: string]: unknown;
-}
+// Data of Element node
+export interface TemplateNodeData {}
 
-// Node
+// Element node
 export interface TemplateNode extends Element, TemplateNodeData {}
 
 // Option type

--- a/packages/slate-plugins/src/__templates__/types-element.template.ts
+++ b/packages/slate-plugins/src/__templates__/types-element.template.ts
@@ -1,0 +1,39 @@
+import { RenderElementOptions } from 'element';
+import { Element } from 'slate';
+import { RenderElementProps } from 'slate-react';
+
+export interface TemplateNodeData {
+  [key: string]: unknown;
+}
+
+// Node
+export interface TemplateNode extends Element, TemplateNodeData {}
+
+// Option type
+interface TypeOption {
+  typeTemplate?: string;
+}
+
+// deserialize options
+export interface TemplateDeserializeOptions extends TypeOption {}
+
+// renderElement options given as props
+interface TemplateRenderElementOptionsProps {}
+
+// renderElement options
+export interface TemplateRenderElementOptions
+  extends RenderElementOptions,
+    TemplateRenderElementOptionsProps,
+    TypeOption {}
+
+// renderElement props
+export interface TemplateRenderElementProps
+  extends RenderElementProps,
+    TemplateRenderElementOptionsProps {
+  element: TemplateNode;
+}
+
+// Plugin options
+export interface TemplatePluginOptions
+  extends TemplateRenderElementOptions,
+    TemplateDeserializeOptions {}

--- a/packages/slate-plugins/src/__templates__/types-leaf.template.ts
+++ b/packages/slate-plugins/src/__templates__/types-leaf.template.ts
@@ -1,0 +1,39 @@
+import { MarkPluginOptions, RenderLeafOptions } from 'mark';
+import { Text } from 'slate';
+import { RenderLeafProps } from 'slate-react';
+
+// Data of Text node
+export interface TemplateNodeData {}
+
+// Text node
+export interface TemplateNode extends Text, TemplateNodeData {}
+
+// Option type
+interface TypeOption {
+  typeTemplate?: string;
+}
+
+// renderLeaf options given as props
+interface TemplateRenderLeafOptionsProps {}
+
+// renderLeaf options
+export interface TemplateRenderLeafOptions
+  extends RenderLeafOptions,
+    TemplateRenderLeafOptionsProps,
+    TypeOption {}
+
+// renderLeaf props
+export interface TemplateRenderLeafProps
+  extends RenderLeafProps,
+    TemplateRenderLeafOptionsProps {
+  leaf: TemplateNode;
+}
+
+// deserialize options
+export interface TemplateDeserializeOptions extends TypeOption {}
+
+// Plugin options
+export interface TemplatePluginOptions
+  extends MarkPluginOptions,
+    TemplateRenderLeafOptions,
+    TemplateDeserializeOptions {}

--- a/packages/slate-plugins/src/__tests__/common/queries/isPointAtWordEnd/element-end.spec.tsx
+++ b/packages/slate-plugins/src/__tests__/common/queries/isPointAtWordEnd/element-end.spec.tsx
@@ -1,0 +1,22 @@
+/** @jsx jsx */
+
+import { jsx } from '__test-utils__/jsx';
+import { isPointAtWordEnd } from 'common/queries';
+import { Editor, Range } from 'slate';
+
+const input = ((
+  <editor>
+    <hp>
+      test
+      <cursor />
+    </hp>
+  </editor>
+) as any) as Editor;
+
+const at = Range.start(input.selection as Range);
+
+const output = true;
+
+it('should be', () => {
+  expect(isPointAtWordEnd(input, { at })).toEqual(output);
+});

--- a/packages/slate-plugins/src/__tests__/common/queries/isPointAtWordEnd/word-end.spec.tsx
+++ b/packages/slate-plugins/src/__tests__/common/queries/isPointAtWordEnd/word-end.spec.tsx
@@ -1,0 +1,22 @@
+/** @jsx jsx */
+
+import { jsx } from '__test-utils__/jsx';
+import { isPointAtWordEnd } from 'common/queries';
+import { Editor, Range } from 'slate';
+
+const input = ((
+  <editor>
+    <hp>
+      test
+      <cursor /> test2
+    </hp>
+  </editor>
+) as any) as Editor;
+
+const at = Range.start(input.selection as Range);
+
+const output = true;
+
+it('should be', () => {
+  expect(isPointAtWordEnd(input, { at })).toEqual(output);
+});

--- a/packages/slate-plugins/src/__tests__/common/queries/isPointAtWordEnd/word-middle.spec.tsx
+++ b/packages/slate-plugins/src/__tests__/common/queries/isPointAtWordEnd/word-middle.spec.tsx
@@ -1,0 +1,23 @@
+/** @jsx jsx */
+
+import { jsx } from '__test-utils__/jsx';
+import { isPointAtWordEnd } from 'common/queries';
+import { Editor, Range } from 'slate';
+
+const input = ((
+  <editor>
+    <hp>
+      test
+      <cursor />
+      test2
+    </hp>
+  </editor>
+) as any) as Editor;
+
+const at = Range.start(input.selection as Range);
+
+const output = false;
+
+it('should be', () => {
+  expect(isPointAtWordEnd(input, { at })).toEqual(output);
+});

--- a/packages/slate-plugins/src/__tests__/common/queries/isWordAfterTrigger/no-trigger.spec.tsx
+++ b/packages/slate-plugins/src/__tests__/common/queries/isWordAfterTrigger/no-trigger.spec.tsx
@@ -1,0 +1,22 @@
+/** @jsx jsx */
+
+import { jsx } from '__test-utils__/jsx';
+import { isWordAfterTrigger } from 'common/queries';
+import { Editor, Range } from 'slate';
+
+const input = ((
+  <editor>
+    <hp>
+      test
+      <cursor /> test2
+    </hp>
+  </editor>
+) as any) as Editor;
+
+const at = Range.start(input.selection as Range);
+
+const output = {};
+
+it('should be', () => {
+  expect(isWordAfterTrigger(input, { at, trigger: '@' })).toEqual(output);
+});

--- a/packages/slate-plugins/src/__tests__/common/queries/isWordAfterTrigger/trigger-space-word.spec.tsx
+++ b/packages/slate-plugins/src/__tests__/common/queries/isWordAfterTrigger/trigger-space-word.spec.tsx
@@ -1,0 +1,20 @@
+/** @jsx jsx */
+
+import { jsx } from '__test-utils__/jsx';
+import { isWordAfterTrigger } from 'common/queries';
+import { Editor, Range } from 'slate';
+
+const input = ((
+  <editor>
+    <hp>
+      @ test
+      <cursor /> test2
+    </hp>
+  </editor>
+) as any) as Editor;
+
+const at = Range.start(input.selection as Range);
+
+it('should be', () => {
+  expect(isWordAfterTrigger(input, { at, trigger: '@' }).match).toBeNull();
+});

--- a/packages/slate-plugins/src/__tests__/common/queries/isWordAfterTrigger/trigger.spec.tsx
+++ b/packages/slate-plugins/src/__tests__/common/queries/isWordAfterTrigger/trigger.spec.tsx
@@ -1,0 +1,24 @@
+/** @jsx jsx */
+
+import { jsx } from '__test-utils__/jsx';
+import { isWordAfterTrigger } from 'common/queries';
+import { Editor, Range } from 'slate';
+
+const input = ((
+  <editor>
+    <hp>
+      @test
+      <cursor /> test2
+    </hp>
+  </editor>
+) as any) as Editor;
+
+const at = Range.start(input.selection as Range);
+
+const output = 'test';
+
+it('should be', () => {
+  expect(isWordAfterTrigger(input, { at, trigger: '@' }).match?.[1]).toBe(
+    output
+  );
+});

--- a/packages/slate-plugins/src/__tests__/components/EditablePlugins/all-plugins.spec.tsx
+++ b/packages/slate-plugins/src/__tests__/components/EditablePlugins/all-plugins.spec.tsx
@@ -98,6 +98,8 @@ import {
   nodeTypes,
 } from '../../../../../../stories/config/initialValues';
 
+const markOptions = { ...nodeTypes, hotkey: '' };
+
 const plugins = [
   BlockquotePlugin(nodeTypes),
   ActionItemPlugin(nodeTypes),
@@ -110,13 +112,21 @@ const plugins = [
   TablePlugin(nodeTypes),
   VideoPlugin(nodeTypes),
   CodePlugin(nodeTypes),
+  BoldPlugin(markOptions),
   BoldPlugin(),
+  InlineCodePlugin(markOptions),
   InlineCodePlugin(),
+  ItalicPlugin(markOptions),
   ItalicPlugin(),
+  StrikethroughPlugin(markOptions),
   StrikethroughPlugin(),
+  HighlightPlugin(markOptions),
   HighlightPlugin(),
+  UnderlinePlugin(markOptions),
   UnderlinePlugin(),
+  SubscriptPlugin(markOptions),
   SubscriptPlugin(),
+  SuperscriptPlugin(markOptions),
   SuperscriptPlugin(),
   SearchHighlightPlugin(),
   SoftBreakPlugin(),

--- a/packages/slate-plugins/src/__tests__/deserializers/deserialize-html/htmlDeserialize/all-deserialize.spec.tsx
+++ b/packages/slate-plugins/src/__tests__/deserializers/deserialize-html/htmlDeserialize/all-deserialize.spec.tsx
@@ -45,7 +45,7 @@ const textTags = [
 
 const inlineTags = [
   '<a href="http://localhost:3000">a</a>',
-  `<span data-slate-type=${MENTION} data-slate-character="zbeyens" />`,
+  `<span data-slate-type=${MENTION} data-slate-value="zbeyens" />`,
 ];
 
 const elementTags = [

--- a/packages/slate-plugins/src/__tests__/elements/image/ImageElement/focused.spec.tsx
+++ b/packages/slate-plugins/src/__tests__/elements/image/ImageElement/focused.spec.tsx
@@ -14,6 +14,7 @@ it('should render', () => {
       element={{
         type: IMAGE,
         children: [{ text: '' }],
+        url: 'test',
       }}
     >
       test

--- a/packages/slate-plugins/src/__tests__/elements/mention/MentionElement/focused.spec.tsx
+++ b/packages/slate-plugins/src/__tests__/elements/mention/MentionElement/focused.spec.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MENTION } from 'elements/mention';
+import { MentionElement } from 'elements/mention/components';
+import * as SlateReact from 'slate-react';
+
+it('should render', () => {
+  jest.spyOn(SlateReact, 'useSelected').mockReturnValue(true);
+  jest.spyOn(SlateReact, 'useFocused').mockReturnValue(true);
+
+  const { getByTestId } = render(
+    <MentionElement
+      attributes={
+        {
+          'data-testid': 'MentionElement',
+        } as any
+      }
+      element={{
+        type: MENTION,
+        children: [{ text: 'test' }],
+        mentionable: {
+          value: 't2',
+        },
+      }}
+    >
+      @t2
+    </MentionElement>
+  );
+
+  expect(getByTestId('MentionElement')).toBeVisible();
+});

--- a/packages/slate-plugins/src/__tests__/elements/mention/MentionSelect/at/null.spec.tsx
+++ b/packages/slate-plugins/src/__tests__/elements/mention/MentionSelect/at/null.spec.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { mentionables } from '__tests__/elements/mention/useMention/onKeyDown/mentionables.fixture';
+import { render } from '@testing-library/react';
+import { MentionSelect } from 'elements/mention/components';
+import * as SlateReact from 'slate-react';
+
+it('should render null', () => {
+  jest.spyOn(SlateReact, 'useSlate').mockReturnValue(null as any);
+
+  const { queryByTestId } = render(
+    <MentionSelect
+      data-testid="MentionSelect"
+      at={null}
+      options={mentionables}
+      valueIndex={0}
+    />
+  );
+
+  expect(queryByTestId('MentionSelect')).toBeNull();
+});

--- a/packages/slate-plugins/src/__tests__/elements/mention/MentionSelect/at/range.spec.tsx
+++ b/packages/slate-plugins/src/__tests__/elements/mention/MentionSelect/at/range.spec.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { mentionables } from '__tests__/elements/mention/useMention/onKeyDown/mentionables.fixture';
+import { render } from '@testing-library/react';
+import { MentionSelect } from 'elements/mention/components';
+import { PARAGRAPH } from 'elements/paragraph';
+import { createEditor } from 'slate';
+import { ReactEditor } from 'slate-react';
+import * as SlateReact from 'slate-react';
+
+it('should render null', () => {
+  const editor = createEditor();
+  editor.children = [
+    {
+      type: PARAGRAPH,
+      children: [
+        {
+          text: '@t2',
+        },
+      ],
+    },
+  ];
+
+  editor.selection = {
+    anchor: { path: [0, 0], offset: 0 },
+    focus: { path: [0, 0], offset: 0 },
+  };
+
+  jest.spyOn(SlateReact, 'useSlate').mockReturnValue(null as any);
+  jest.spyOn(ReactEditor, 'toDOMRange').mockReturnValue({
+    getBoundingClientRect: () => ({
+      top: 1,
+      left: 1,
+      width: 100,
+    }),
+  } as any);
+
+  const { getByTestId } = render(
+    <MentionSelect
+      data-testid="MentionSelect"
+      at={editor.selection}
+      options={mentionables}
+      valueIndex={0}
+    />
+  );
+
+  expect(getByTestId('MentionSelect')).toBeVisible();
+});

--- a/packages/slate-plugins/src/__tests__/elements/mention/default-prefix.spec.tsx
+++ b/packages/slate-plugins/src/__tests__/elements/mention/default-prefix.spec.tsx
@@ -16,7 +16,7 @@ const output = (
   <editor>
     <hp>
       <htext />
-      <element type="mention" prefix="@" mentionable={{ value: 'Count Duku' }}>
+      <element type="mention" mentionable={{ value: 'Count Duku' }}>
         <htext />
       </element>
       <htext />
@@ -29,7 +29,6 @@ it('should insert mention', () => {
 
   editor.insertNode({
     type: 'mention',
-    prefix: '@',
     mentionable: { value: 'Count Duku' },
     children: [{ text: '' }],
   });

--- a/packages/slate-plugins/src/__tests__/elements/mention/useMention/default.spec.tsx
+++ b/packages/slate-plugins/src/__tests__/elements/mention/useMention/default.spec.tsx
@@ -1,0 +1,8 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useMention } from 'elements/mention';
+
+it('should be', () => {
+  const { result } = renderHook(() => useMention());
+
+  expect(result.current.index).toBe(0);
+});

--- a/packages/slate-plugins/src/__tests__/elements/mention/useMention/onChangeMention/match.spec.tsx
+++ b/packages/slate-plugins/src/__tests__/elements/mention/useMention/onChangeMention/match.spec.tsx
@@ -1,0 +1,33 @@
+/** @jsx jsx */
+import { jsx } from '__test-utils__/jsx';
+import { act, renderHook } from '@testing-library/react-hooks';
+import { pipe } from 'common/pipe';
+import { useMention, withMention } from 'elements/mention';
+import { Editor } from 'slate';
+import { withHistory } from 'slate-history';
+import { withReact } from 'slate-react';
+
+const input = ((
+  <editor>
+    <hp>
+      t1 @t2
+      <cursor />
+    </hp>
+  </editor>
+) as any) as Editor;
+
+const output = 't2';
+
+const withPlugins = [withReact, withHistory, withMention()] as const;
+
+it('should do nothing', () => {
+  const editor = pipe(input, ...withPlugins);
+
+  const { result } = renderHook(() => useMention());
+
+  act(() => {
+    result.current.onChangeMention(editor);
+  });
+
+  expect(result.current.search).toEqual(output);
+});

--- a/packages/slate-plugins/src/__tests__/elements/mention/useMention/onChangeMention/no-selection.spec.tsx
+++ b/packages/slate-plugins/src/__tests__/elements/mention/useMention/onChangeMention/no-selection.spec.tsx
@@ -1,0 +1,28 @@
+/** @jsx jsx */
+import { jsx } from '__test-utils__/jsx';
+import { act, renderHook } from '@testing-library/react-hooks';
+import { pipe } from 'common/pipe';
+import { useMention, withMention } from 'elements/mention';
+import { Editor } from 'slate';
+import { withHistory } from 'slate-history';
+import { withReact } from 'slate-react';
+
+const input = ((
+  <editor>
+    <hp>test</hp>
+  </editor>
+) as any) as Editor;
+
+const withPlugins = [withReact, withHistory, withMention()] as const;
+
+it('should do nothing', () => {
+  const editor = pipe(input, ...withPlugins);
+
+  const { result } = renderHook(() => useMention());
+
+  act(() => {
+    result.current.onChangeMention(editor);
+  });
+
+  expect(result.current.index).toBe(0);
+});

--- a/packages/slate-plugins/src/__tests__/elements/mention/useMention/onChangeMention/without-trigger.spec.tsx
+++ b/packages/slate-plugins/src/__tests__/elements/mention/useMention/onChangeMention/without-trigger.spec.tsx
@@ -1,0 +1,31 @@
+/** @jsx jsx */
+import { jsx } from '__test-utils__/jsx';
+import { act, renderHook } from '@testing-library/react-hooks';
+import { pipe } from 'common/pipe';
+import { useMention, withMention } from 'elements/mention';
+import { Editor } from 'slate';
+import { withHistory } from 'slate-history';
+import { withReact } from 'slate-react';
+
+const input = ((
+  <editor>
+    <hp>
+      test
+      <cursor />
+    </hp>
+  </editor>
+) as any) as Editor;
+
+const withPlugins = [withReact, withHistory, withMention()] as const;
+
+it('should do nothing', () => {
+  const editor = pipe(input, ...withPlugins);
+
+  const { result } = renderHook(() => useMention());
+
+  act(() => {
+    result.current.onChangeMention(editor);
+  });
+
+  expect(result.current.index).toBe(0);
+});

--- a/packages/slate-plugins/src/__tests__/elements/mention/useMention/onKeyDown/default.spec.tsx
+++ b/packages/slate-plugins/src/__tests__/elements/mention/useMention/onKeyDown/default.spec.tsx
@@ -1,0 +1,39 @@
+/** @jsx jsx */
+import { jsx } from '__test-utils__/jsx';
+import { mentionables } from '__tests__/elements/mention/useMention/onKeyDown/mentionables.fixture';
+import { act, renderHook } from '@testing-library/react-hooks';
+import { pipe } from 'common/pipe';
+import { useMention, withMention } from 'elements/mention';
+import { Editor } from 'slate';
+import { withHistory } from 'slate-history';
+import { withReact } from 'slate-react';
+
+const input = ((
+  <editor>
+    <hp>
+      t1 @t2
+      <cursor />
+    </hp>
+  </editor>
+) as any) as Editor;
+
+const withPlugins = [withReact, withHistory, withMention()] as const;
+
+it('should go down', () => {
+  const editor = pipe(input, ...withPlugins);
+
+  const { result } = renderHook(() => useMention(mentionables));
+
+  act(() => {
+    result.current.onChangeMention(editor);
+  });
+
+  act(() => {
+    result.current.onKeyDownMention(
+      new KeyboardEvent('keydown', { key: 'a' }),
+      editor
+    );
+  });
+
+  expect(result.current.target).toBeDefined();
+});

--- a/packages/slate-plugins/src/__tests__/elements/mention/useMention/onKeyDown/down-end.spec.tsx
+++ b/packages/slate-plugins/src/__tests__/elements/mention/useMention/onKeyDown/down-end.spec.tsx
@@ -1,0 +1,51 @@
+/** @jsx jsx */
+import { jsx } from '__test-utils__/jsx';
+import { mentionables } from '__tests__/elements/mention/useMention/onKeyDown/mentionables.fixture';
+import { act, renderHook } from '@testing-library/react-hooks';
+import { pipe } from 'common/pipe';
+import { useMention, withMention } from 'elements/mention';
+import { Editor } from 'slate';
+import { withHistory } from 'slate-history';
+import { withReact } from 'slate-react';
+
+const input = ((
+  <editor>
+    <hp>
+      t1 @t2
+      <cursor />
+    </hp>
+  </editor>
+) as any) as Editor;
+
+const withPlugins = [withReact, withHistory, withMention()] as const;
+
+it('should go down then back to the first index', () => {
+  const editor = pipe(input, ...withPlugins);
+
+  const { result } = renderHook(() => useMention(mentionables));
+
+  act(() => {
+    result.current.onChangeMention(editor);
+  });
+
+  act(() => {
+    result.current.onKeyDownMention(
+      new KeyboardEvent('keydown', { key: 'ArrowDown' }),
+      editor
+    );
+  });
+  act(() => {
+    result.current.onKeyDownMention(
+      new KeyboardEvent('keydown', { key: 'ArrowDown' }),
+      editor
+    );
+  });
+  act(() => {
+    result.current.onKeyDownMention(
+      new KeyboardEvent('keydown', { key: 'ArrowDown' }),
+      editor
+    );
+  });
+
+  expect(result.current.index).toBe(0);
+});

--- a/packages/slate-plugins/src/__tests__/elements/mention/useMention/onKeyDown/down.spec.tsx
+++ b/packages/slate-plugins/src/__tests__/elements/mention/useMention/onKeyDown/down.spec.tsx
@@ -1,0 +1,39 @@
+/** @jsx jsx */
+import { jsx } from '__test-utils__/jsx';
+import { mentionables } from '__tests__/elements/mention/useMention/onKeyDown/mentionables.fixture';
+import { act, renderHook } from '@testing-library/react-hooks';
+import { pipe } from 'common/pipe';
+import { useMention, withMention } from 'elements/mention';
+import { Editor } from 'slate';
+import { withHistory } from 'slate-history';
+import { withReact } from 'slate-react';
+
+const input = ((
+  <editor>
+    <hp>
+      t1 @t2
+      <cursor />
+    </hp>
+  </editor>
+) as any) as Editor;
+
+const withPlugins = [withReact, withHistory, withMention()] as const;
+
+it('should go down', () => {
+  const editor = pipe(input, ...withPlugins);
+
+  const { result } = renderHook(() => useMention(mentionables));
+
+  act(() => {
+    result.current.onChangeMention(editor);
+  });
+
+  act(() => {
+    result.current.onKeyDownMention(
+      new KeyboardEvent('keydown', { key: 'ArrowDown' }),
+      editor
+    );
+  });
+
+  expect(result.current.index).toBe(1);
+});

--- a/packages/slate-plugins/src/__tests__/elements/mention/useMention/onKeyDown/enter.spec.tsx
+++ b/packages/slate-plugins/src/__tests__/elements/mention/useMention/onKeyDown/enter.spec.tsx
@@ -1,0 +1,52 @@
+/** @jsx jsx */
+import { jsx } from '__test-utils__/jsx';
+import { mentionables } from '__tests__/elements/mention/useMention/onKeyDown/mentionables.fixture';
+import { act, renderHook } from '@testing-library/react-hooks';
+import { pipe } from 'common/pipe';
+import { useMention, withMention } from 'elements/mention';
+import { Editor } from 'slate';
+import { withHistory } from 'slate-history';
+import { withReact } from 'slate-react';
+
+const input = ((
+  <editor>
+    <hp>
+      t1 @t2
+      <cursor />
+    </hp>
+  </editor>
+) as any) as Editor;
+
+const output = ((
+  <editor>
+    <hp>
+      t1{' '}
+      <hmention value="t2">
+        <htext />
+      </hmention>
+      <cursor />
+    </hp>
+  </editor>
+) as any) as Editor;
+
+const withPlugins = [withReact, withHistory, withMention()] as const;
+
+it('should go down', () => {
+  const editor = pipe(input, ...withPlugins);
+
+  const { result } = renderHook(() => useMention(mentionables));
+
+  act(() => {
+    result.current.onChangeMention(editor);
+  });
+
+  act(() => {
+    result.current.onKeyDownMention(
+      new KeyboardEvent('keydown', { key: 'Enter' }),
+      editor
+    );
+  });
+
+  expect(input.children).toEqual(output.children);
+  expect(result.current.target).toEqual(null);
+});

--- a/packages/slate-plugins/src/__tests__/elements/mention/useMention/onKeyDown/escape.spec.tsx
+++ b/packages/slate-plugins/src/__tests__/elements/mention/useMention/onKeyDown/escape.spec.tsx
@@ -1,0 +1,39 @@
+/** @jsx jsx */
+import { jsx } from '__test-utils__/jsx';
+import { mentionables } from '__tests__/elements/mention/useMention/onKeyDown/mentionables.fixture';
+import { act, renderHook } from '@testing-library/react-hooks';
+import { pipe } from 'common/pipe';
+import { useMention, withMention } from 'elements/mention';
+import { Editor } from 'slate';
+import { withHistory } from 'slate-history';
+import { withReact } from 'slate-react';
+
+const input = ((
+  <editor>
+    <hp>
+      t1 @t2
+      <cursor />
+    </hp>
+  </editor>
+) as any) as Editor;
+
+const withPlugins = [withReact, withHistory, withMention()] as const;
+
+it('should go down', () => {
+  const editor = pipe(input, ...withPlugins);
+
+  const { result } = renderHook(() => useMention(mentionables));
+
+  act(() => {
+    result.current.onChangeMention(editor);
+  });
+
+  act(() => {
+    result.current.onKeyDownMention(
+      new KeyboardEvent('keydown', { key: 'Escape' }),
+      editor
+    );
+  });
+
+  expect(result.current.target).toEqual(null);
+});

--- a/packages/slate-plugins/src/__tests__/elements/mention/useMention/onKeyDown/mentionables.fixture.tsx
+++ b/packages/slate-plugins/src/__tests__/elements/mention/useMention/onKeyDown/mentionables.fixture.tsx
@@ -1,0 +1,19 @@
+/** @jsx jsx */
+import { jsx } from '__test-utils__/jsx';
+import { MentionableItem } from 'elements/mention';
+import { Editor } from 'slate';
+
+export const editorWithMentionable = ((
+  <editor>
+    <hp>
+      t1 @t2
+      <cursor />
+    </hp>
+  </editor>
+) as any) as Editor;
+
+export const mentionables: MentionableItem[] = [
+  { value: 't2' },
+  { value: 't22' },
+  { value: 't222' },
+];

--- a/packages/slate-plugins/src/__tests__/elements/mention/useMention/onKeyDown/mentionables.fixture.tsx
+++ b/packages/slate-plugins/src/__tests__/elements/mention/useMention/onKeyDown/mentionables.fixture.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from '__test-utils__/jsx';
-import { MentionableItem } from 'elements/mention';
+import { MentionNodeData } from 'elements/mention';
 import { Editor } from 'slate';
 
 export const editorWithMentionable = ((
@@ -12,7 +12,7 @@ export const editorWithMentionable = ((
   </editor>
 ) as any) as Editor;
 
-export const mentionables: MentionableItem[] = [
+export const mentionables: MentionNodeData[] = [
   { value: 't2' },
   { value: 't22' },
   { value: 't222' },

--- a/packages/slate-plugins/src/__tests__/elements/mention/useMention/onKeyDown/no-target.spec.tsx
+++ b/packages/slate-plugins/src/__tests__/elements/mention/useMention/onKeyDown/no-target.spec.tsx
@@ -1,0 +1,21 @@
+/** @jsx jsx */
+import { jsx } from '__test-utils__/jsx';
+import { act, renderHook } from '@testing-library/react-hooks';
+import { useMention } from 'elements/mention';
+import { Editor } from 'slate';
+
+const input = ((
+  <editor>
+    <hp>test</hp>
+  </editor>
+) as any) as Editor;
+
+it('should be', () => {
+  const { result } = renderHook(() => useMention());
+
+  act(() => {
+    result.current.onKeyDownMention(new KeyboardEvent('ArrowDown'), input);
+  });
+
+  expect(result.current.index).toBe(0);
+});

--- a/packages/slate-plugins/src/__tests__/elements/mention/useMention/onKeyDown/up-end.spec.tsx
+++ b/packages/slate-plugins/src/__tests__/elements/mention/useMention/onKeyDown/up-end.spec.tsx
@@ -1,0 +1,46 @@
+/** @jsx jsx */
+import { jsx } from '__test-utils__/jsx';
+import { mentionables } from '__tests__/elements/mention/useMention/onKeyDown/mentionables.fixture';
+import { act, renderHook } from '@testing-library/react-hooks';
+import { pipe } from 'common/pipe';
+import { useMention, withMention } from 'elements/mention';
+import { Editor } from 'slate';
+import { withHistory } from 'slate-history';
+import { withReact } from 'slate-react';
+
+const input = ((
+  <editor>
+    <hp>
+      t1 @t2
+      <cursor />
+    </hp>
+  </editor>
+) as any) as Editor;
+
+const withPlugins = [withReact, withHistory, withMention()] as const;
+
+it('should go down', () => {
+  const editor = pipe(input, ...withPlugins);
+
+  const { result } = renderHook(() => useMention(mentionables));
+
+  act(() => {
+    result.current.onChangeMention(editor);
+  });
+
+  act(() => {
+    result.current.onKeyDownMention(
+      new KeyboardEvent('keydown', { key: 'ArrowUp' }),
+      editor
+    );
+  });
+
+  act(() => {
+    result.current.onKeyDownMention(
+      new KeyboardEvent('keydown', { key: 'ArrowUp' }),
+      editor
+    );
+  });
+
+  expect(result.current.index).toBe(1);
+});

--- a/packages/slate-plugins/src/__tests__/elements/mention/useMention/onKeyDown/up.spec.tsx
+++ b/packages/slate-plugins/src/__tests__/elements/mention/useMention/onKeyDown/up.spec.tsx
@@ -1,0 +1,39 @@
+/** @jsx jsx */
+import { jsx } from '__test-utils__/jsx';
+import { mentionables } from '__tests__/elements/mention/useMention/onKeyDown/mentionables.fixture';
+import { act, renderHook } from '@testing-library/react-hooks';
+import { pipe } from 'common/pipe';
+import { useMention, withMention } from 'elements/mention';
+import { Editor } from 'slate';
+import { withHistory } from 'slate-history';
+import { withReact } from 'slate-react';
+
+const input = ((
+  <editor>
+    <hp>
+      t1 @t2
+      <cursor />
+    </hp>
+  </editor>
+) as any) as Editor;
+
+const withPlugins = [withReact, withHistory, withMention()] as const;
+
+it('should go down', () => {
+  const editor = pipe(input, ...withPlugins);
+
+  const { result } = renderHook(() => useMention(mentionables));
+
+  act(() => {
+    result.current.onChangeMention(editor);
+  });
+
+  act(() => {
+    result.current.onKeyDownMention(
+      new KeyboardEvent('keydown', { key: 'ArrowUp' }),
+      editor
+    );
+  });
+
+  expect(result.current.index).toBe(2);
+});

--- a/packages/slate-plugins/src/__tests__/mark/onKeyDownMark/invalid.spec.tsx
+++ b/packages/slate-plugins/src/__tests__/mark/onKeyDownMark/invalid.spec.tsx
@@ -27,7 +27,7 @@ const output = (
 ) as any;
 
 it('should be', () => {
-  onKeyDownMark({ hotkey: 'enter', type: MARK_BOLD })(event, input);
+  onKeyDownMark(MARK_BOLD, 'enter')(event, input);
   expect(input.children).toEqual(output.children);
   expect(input.selection).toEqual(output.selection);
 });

--- a/packages/slate-plugins/src/__tests__/mark/onKeyDownMark/valid-clear.spec.tsx
+++ b/packages/slate-plugins/src/__tests__/mark/onKeyDownMark/valid-clear.spec.tsx
@@ -35,10 +35,7 @@ const output = (
 it('should be', () => {
   jest.spyOn(isHotkey, 'default').mockReturnValue(true);
 
-  onKeyDownMark({ hotkey: 'ctrl+b', type: MARK_BOLD, clear: MARK_ITALIC })(
-    event,
-    input
-  );
+  onKeyDownMark(MARK_BOLD, 'ctrl+b', { clear: MARK_ITALIC })(event, input);
   expect(input.children).toEqual(output.children);
   expect(input.selection).toEqual(output.selection);
 });

--- a/packages/slate-plugins/src/__tests__/mark/onKeyDownMark/valid.spec.tsx
+++ b/packages/slate-plugins/src/__tests__/mark/onKeyDownMark/valid.spec.tsx
@@ -32,7 +32,7 @@ const output = (
 it('should be', () => {
   jest.spyOn(isHotkey, 'default').mockReturnValue(true);
 
-  onKeyDownMark({ hotkey: 'ctrl+b', type: MARK_BOLD })(event, input);
+  onKeyDownMark(MARK_BOLD, 'ctrl+b')(event, input);
   expect(input.children).toEqual(output.children);
   expect(input.selection).toEqual(output.selection);
 });

--- a/packages/slate-plugins/src/common/queries/index.ts
+++ b/packages/slate-plugins/src/common/queries/index.ts
@@ -7,3 +7,5 @@ export * from './isPointAtRoot';
 export * from './isRangeAtRoot';
 export * from './isAncestor';
 export * from './isDescendant';
+export * from './isPointAtWordEnd';
+export * from './isWordAfterTrigger';

--- a/packages/slate-plugins/src/common/queries/isPointAtWordEnd.ts
+++ b/packages/slate-plugins/src/common/queries/isPointAtWordEnd.ts
@@ -1,0 +1,19 @@
+import { Editor, Point } from 'slate';
+
+// Starts with whitespace char or nothing
+const AFTER_MATCH_REGEX = /^(\s|$)/;
+
+/**
+ * Is a point at the end of a word
+ */
+export const isPointAtWordEnd = (editor: Editor, { at }: { at: Point }) => {
+  // Point after at
+  const after = Editor.after(editor, at);
+
+  // From at to after
+  const afterRange = Editor.range(editor, at, after);
+  const afterText = Editor.string(editor, afterRange);
+
+  // Match regex on after text
+  return !!afterText.match(AFTER_MATCH_REGEX);
+};

--- a/packages/slate-plugins/src/common/queries/isWordAfterTrigger.ts
+++ b/packages/slate-plugins/src/common/queries/isWordAfterTrigger.ts
@@ -1,0 +1,36 @@
+import { escapeRegExp } from 'common/utils';
+import { Editor, Point } from 'slate';
+
+/**
+ * Is the word at the point after a trigger (punctuation character)
+ * https://github.com/ianstormtaylor/slate/blob/master/packages/slate/src/utils/string.ts#L6
+ */
+export const isWordAfterTrigger = (
+  editor: Editor,
+  { at, trigger }: { at: Point; trigger: string }
+) => {
+  // Point at the start of previous word (excluding punctuation)
+  // https://github.com/ianstormtaylor/slate/blob/master/packages/slate/src/utils/string.ts#L6
+  const wordBefore = Editor.before(editor, at, { unit: 'word' });
+
+  // Point before wordBefore
+  const before = wordBefore && Editor.before(editor, wordBefore);
+
+  // Range from before to start
+  const beforeRange = before && Editor.range(editor, before, at);
+
+  // Before text
+  const beforeText = beforeRange && Editor.string(editor, beforeRange);
+
+  // Starts with char and ends with word characters
+  const escapedTrigger = escapeRegExp(trigger);
+  const beforeRegex = new RegExp(`^${escapedTrigger}(\\w+)$`);
+
+  // Match regex on before text
+  const match = beforeText && beforeText.match(beforeRegex);
+
+  return {
+    range: beforeRange,
+    match,
+  };
+};

--- a/packages/slate-plugins/src/common/types.ts
+++ b/packages/slate-plugins/src/common/types.ts
@@ -35,7 +35,7 @@ export interface TElement extends Element {
 export type RenderLeaf = (props: RenderLeafProps) => JSX.Element;
 
 // Handler when we press a key.
-export type OnKeyDown = (e: any, editor: Editor, props?: any) => void;
+export type OnKeyDown = (e: any, editor: Editor, options?: any) => void;
 
 export type DeserializeElement = Record<
   string,

--- a/packages/slate-plugins/src/common/types.ts
+++ b/packages/slate-plugins/src/common/types.ts
@@ -1,4 +1,4 @@
-import { Editor, Element, NodeEntry, Range } from 'slate';
+import { Editor, NodeEntry, Range } from 'slate';
 import { RenderElementProps, RenderLeafProps } from 'slate-react';
 
 /**
@@ -21,10 +21,6 @@ export type OnDOMBeforeInput = (event: Event, editor: Editor) => void;
 export type RenderElement = (
   props: RenderElementProps
 ) => JSX.Element | undefined;
-
-export interface TElement extends Element {
-  type: string;
-}
 
 /**
  * To customize the rendering of each leaf.
@@ -78,6 +74,6 @@ export interface SlatePlugin {
   onDOMBeforeInput?: OnDOMBeforeInput;
   renderElement?: RenderElement;
   renderLeaf?: RenderLeaf;
-  onKeyDown?: OnKeyDown;
+  onKeyDown?: OnKeyDown | null;
   deserialize?: DeserializeHtml;
 }

--- a/packages/slate-plugins/src/common/types.ts
+++ b/packages/slate-plugins/src/common/types.ts
@@ -1,4 +1,4 @@
-import { Editor, NodeEntry, Range } from 'slate';
+import { Editor, Element, NodeEntry, Range } from 'slate';
 import { RenderElementProps, RenderLeafProps } from 'slate-react';
 
 /**
@@ -21,6 +21,10 @@ export type OnDOMBeforeInput = (event: Event, editor: Editor) => void;
 export type RenderElement = (
   props: RenderElementProps
 ) => JSX.Element | undefined;
+
+export interface TElement extends Element {
+  type: string;
+}
 
 /**
  * To customize the rendering of each leaf.

--- a/packages/slate-plugins/src/element/types.ts
+++ b/packages/slate-plugins/src/element/types.ts
@@ -23,5 +23,4 @@ export interface GetRenderElementOptions {
 
 export interface RenderElementOptions {
   component?: any;
-  [key: string]: any;
 }

--- a/packages/slate-plugins/src/element/types.ts
+++ b/packages/slate-plugins/src/element/types.ts
@@ -7,8 +7,18 @@ export interface ToggleBlockEditor extends Editor {
 }
 
 export interface GetRenderElementOptions {
+  /**
+   * Type of the element
+   */
   type: string;
+  /**
+   * React component to render the element
+   */
   component: any;
+  /**
+   * Options passed to the component as props
+   */
+  [key: string]: any;
 }
 
 export interface RenderElementOptions {

--- a/packages/slate-plugins/src/element/utils/getRenderElement.tsx
+++ b/packages/slate-plugins/src/element/utils/getRenderElement.tsx
@@ -8,6 +8,7 @@ import { GetRenderElementOptions } from '../types';
 export const getRenderElement = ({
   type,
   component: Component,
+  ...options
 }: GetRenderElementOptions) => ({
   attributes,
   ...props
@@ -17,6 +18,7 @@ export const getRenderElement = ({
       <Component
         attributes={{ 'data-slate-type': type, ...attributes }}
         {...props}
+        {...options}
       />
     );
   }

--- a/packages/slate-plugins/src/elements/action-item/ActionItemPlugin.ts
+++ b/packages/slate-plugins/src/elements/action-item/ActionItemPlugin.ts
@@ -1,10 +1,10 @@
 import { SlatePlugin } from 'common/types';
-import { RenderElementOptions } from 'element';
 import { deserializeActionItem } from 'elements/action-item/deserializeActionItem';
+import { ActionItemPluginOptions } from 'elements/action-item/types';
 import { renderElementActionItem } from './renderElementActionItem';
 
 export const ActionItemPlugin = (
-  options?: RenderElementOptions & { typeActionItem?: string }
+  options?: ActionItemPluginOptions
 ): SlatePlugin => ({
   renderElement: renderElementActionItem(options),
   deserialize: deserializeActionItem(options),

--- a/packages/slate-plugins/src/elements/action-item/components/ActionItemElement.tsx
+++ b/packages/slate-plugins/src/elements/action-item/components/ActionItemElement.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
+import { ActionItemRenderElementProps } from 'elements/action-item/types';
 import { Transforms } from 'slate';
-import {
-  ReactEditor,
-  RenderElementProps,
-  useEditor,
-  useReadOnly,
-} from 'slate-react';
+import { ReactEditor, useEditor, useReadOnly } from 'slate-react';
 import styled from 'styled-components';
 
 const Wrapper = styled.div`
@@ -44,10 +40,10 @@ export const ActionItemElement = ({
   attributes,
   children,
   element,
-}: RenderElementProps) => {
+}: ActionItemRenderElementProps) => {
   const editor = useEditor();
   const readOnly = useReadOnly();
-  const checked = element.checked as boolean;
+  const { checked } = element;
 
   return (
     <Wrapper {...attributes} data-slate-checked={element.checked}>

--- a/packages/slate-plugins/src/elements/action-item/deserializeActionItem.ts
+++ b/packages/slate-plugins/src/elements/action-item/deserializeActionItem.ts
@@ -1,10 +1,13 @@
 import { DeserializeHtml } from 'common/types';
 import { getElementDeserializer } from 'element/utils';
-import { ACTION_ITEM } from 'elements/action-item/types';
+import {
+  ACTION_ITEM,
+  ActionItemDeserializeOptions,
+} from 'elements/action-item/types';
 
 export const deserializeActionItem = ({
   typeActionItem = ACTION_ITEM,
-} = {}): DeserializeHtml => ({
+}: ActionItemDeserializeOptions = {}): DeserializeHtml => ({
   element: getElementDeserializer(typeActionItem, {
     createElement: (el) => ({
       type: typeActionItem,

--- a/packages/slate-plugins/src/elements/action-item/renderElementActionItem.ts
+++ b/packages/slate-plugins/src/elements/action-item/renderElementActionItem.ts
@@ -1,11 +1,11 @@
-import { getRenderElement, RenderElementOptions } from 'element';
+import { getRenderElement } from 'element';
 import { ActionItemElement } from './components';
-import { ACTION_ITEM } from './types';
+import { ACTION_ITEM, ActionItemRenderElementOptions } from './types';
 
 export const renderElementActionItem = ({
   typeActionItem = ACTION_ITEM,
   component = ActionItemElement,
-}: RenderElementOptions = {}) =>
+}: ActionItemRenderElementOptions = {}) =>
   getRenderElement({
     type: typeActionItem,
     component,

--- a/packages/slate-plugins/src/elements/action-item/types.ts
+++ b/packages/slate-plugins/src/elements/action-item/types.ts
@@ -1,17 +1,15 @@
-import { TemplateDeserializeOptions } from '__templates__/types-element.template';
 import { RenderElementOptions } from 'element';
 import { Element } from 'slate';
 import { RenderElementProps } from 'slate-react';
 
 export const ACTION_ITEM = 'action_item';
 
-// Node data
+// Data of Element node
 export interface ActionItemNodeData {
   checked: boolean;
-  [key: string]: unknown;
 }
 
-// Node
+// Element node
 export interface ActionItemNode extends Element, ActionItemNodeData {}
 
 // Option type

--- a/packages/slate-plugins/src/elements/action-item/types.ts
+++ b/packages/slate-plugins/src/elements/action-item/types.ts
@@ -1,1 +1,44 @@
+import { TemplateDeserializeOptions } from '__templates__/types-element.template';
+import { RenderElementOptions } from 'element';
+import { Element } from 'slate';
+import { RenderElementProps } from 'slate-react';
+
 export const ACTION_ITEM = 'action_item';
+
+// Node data
+export interface ActionItemNodeData {
+  checked: boolean;
+  [key: string]: unknown;
+}
+
+// Node
+export interface ActionItemNode extends Element, ActionItemNodeData {}
+
+// Option type
+interface TypeOption {
+  typeActionItem?: string;
+}
+
+// deserialize options
+export interface ActionItemDeserializeOptions extends TypeOption {}
+
+// renderElement options given as props
+interface ActionItemRenderElementOptionsProps {}
+
+// renderElement options
+export interface ActionItemRenderElementOptions
+  extends RenderElementOptions,
+    ActionItemRenderElementOptionsProps,
+    TypeOption {}
+
+// renderElement props
+export interface ActionItemRenderElementProps
+  extends RenderElementProps,
+    ActionItemRenderElementOptionsProps {
+  element: ActionItemNode;
+}
+
+// Plugin options
+export interface ActionItemPluginOptions
+  extends ActionItemRenderElementOptions,
+    ActionItemDeserializeOptions {}

--- a/packages/slate-plugins/src/elements/blockquote/BlockquotePlugin.ts
+++ b/packages/slate-plugins/src/elements/blockquote/BlockquotePlugin.ts
@@ -1,10 +1,10 @@
 import { SlatePlugin } from 'common/types';
-import { RenderElementOptions } from 'element';
+import { BlockquotePluginOptions } from 'elements/blockquote/types';
 import { deserializeBlockquote } from './deserializeBlockquote';
 import { renderElementBlockquote } from './renderElementBlockquote';
 
 export const BlockquotePlugin = (
-  options?: RenderElementOptions & { typeBlockquote?: string }
+  options?: BlockquotePluginOptions
 ): SlatePlugin => ({
   renderElement: renderElementBlockquote(options),
   deserialize: deserializeBlockquote(options),

--- a/packages/slate-plugins/src/elements/blockquote/components/BlockquoteElement.tsx
+++ b/packages/slate-plugins/src/elements/blockquote/components/BlockquoteElement.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { RenderElementProps } from 'slate-react';
+import { BlockquoteRenderElementProps } from 'elements/blockquote/types';
 import styled from 'styled-components';
 
 const StyledBlockquoteElement = styled.blockquote`
@@ -13,6 +13,6 @@ const StyledBlockquoteElement = styled.blockquote`
 export const BlockquoteElement = ({
   attributes,
   children,
-}: RenderElementProps) => (
+}: BlockquoteRenderElementProps) => (
   <StyledBlockquoteElement {...attributes}>{children}</StyledBlockquoteElement>
 );

--- a/packages/slate-plugins/src/elements/blockquote/deserializeBlockquote.ts
+++ b/packages/slate-plugins/src/elements/blockquote/deserializeBlockquote.ts
@@ -1,9 +1,9 @@
 import { DeserializeHtml } from 'common/types';
 import { getElementDeserializer } from 'element/utils';
-import { BLOCKQUOTE } from './types';
+import { BLOCKQUOTE, BlockquoteDeserializeOptions } from './types';
 
 export const deserializeBlockquote = ({
   typeBlockquote = BLOCKQUOTE,
-} = {}): DeserializeHtml => ({
+}: BlockquoteDeserializeOptions = {}): DeserializeHtml => ({
   element: getElementDeserializer(typeBlockquote, { tagNames: ['BLOCKQUOTE'] }),
 });

--- a/packages/slate-plugins/src/elements/blockquote/renderElementBlockquote.ts
+++ b/packages/slate-plugins/src/elements/blockquote/renderElementBlockquote.ts
@@ -1,11 +1,11 @@
-import { getRenderElement, RenderElementOptions } from 'element';
+import { getRenderElement } from 'element';
 import { BlockquoteElement } from './components';
-import { BLOCKQUOTE } from './types';
+import { BLOCKQUOTE, BlockquoteRenderElementOptions } from './types';
 
 export const renderElementBlockquote = ({
   typeBlockquote = BLOCKQUOTE,
   component = BlockquoteElement,
-}: RenderElementOptions = {}) =>
+}: BlockquoteRenderElementOptions = {}) =>
   getRenderElement({
     type: typeBlockquote,
     component,

--- a/packages/slate-plugins/src/elements/blockquote/types.ts
+++ b/packages/slate-plugins/src/elements/blockquote/types.ts
@@ -4,11 +4,10 @@ import { RenderElementProps } from 'slate-react';
 
 export const BLOCKQUOTE = 'blockquote';
 
-export interface BlockquoteNodeData {
-  [key: string]: unknown;
-}
+// Data of Element node
+export interface BlockquoteNodeData {}
 
-// Node
+// Element node
 export interface BlockquoteNode extends Element, BlockquoteNodeData {}
 
 // Option type

--- a/packages/slate-plugins/src/elements/blockquote/types.ts
+++ b/packages/slate-plugins/src/elements/blockquote/types.ts
@@ -1,1 +1,41 @@
+import { RenderElementOptions } from 'element';
+import { Element } from 'slate';
+import { RenderElementProps } from 'slate-react';
+
 export const BLOCKQUOTE = 'blockquote';
+
+export interface BlockquoteNodeData {
+  [key: string]: unknown;
+}
+
+// Node
+export interface BlockquoteNode extends Element, BlockquoteNodeData {}
+
+// Option type
+interface TypeOption {
+  typeBlockquote?: string;
+}
+
+// deserialize options
+export interface BlockquoteDeserializeOptions extends TypeOption {}
+
+// renderElement options given as props
+interface BlockquoteRenderElementOptionsProps {}
+
+// renderElement options
+export interface BlockquoteRenderElementOptions
+  extends RenderElementOptions,
+    BlockquoteRenderElementOptionsProps,
+    TypeOption {}
+
+// renderElement props
+export interface BlockquoteRenderElementProps
+  extends RenderElementProps,
+    BlockquoteRenderElementOptionsProps {
+  element: BlockquoteNode;
+}
+
+// Plugin options
+export interface BlockquotePluginOptions
+  extends BlockquoteRenderElementOptions,
+    BlockquoteDeserializeOptions {}

--- a/packages/slate-plugins/src/elements/code/CodePlugin.ts
+++ b/packages/slate-plugins/src/elements/code/CodePlugin.ts
@@ -1,11 +1,9 @@
 import { SlatePlugin } from 'common/types';
-import { RenderElementOptions } from 'element';
+import { CodePluginOptions } from 'elements/code/types';
 import { deserializeCode } from './deserializeCode';
 import { renderElementCode } from './renderElementCode';
 
-export const CodePlugin = (
-  options?: RenderElementOptions & { typeCode?: string }
-): SlatePlugin => ({
+export const CodePlugin = (options?: CodePluginOptions): SlatePlugin => ({
   renderElement: renderElementCode(options),
   deserialize: deserializeCode(options),
 });

--- a/packages/slate-plugins/src/elements/code/components/CodeElement.tsx
+++ b/packages/slate-plugins/src/elements/code/components/CodeElement.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { RenderElementProps } from 'slate-react';
+import { CodeRenderElementProps } from 'elements/code/types';
 import styled from 'styled-components';
 
 const Pre = styled.pre`
@@ -8,7 +8,10 @@ const Pre = styled.pre`
   white-space: pre-wrap;
 `;
 
-export const CodeElement = ({ attributes, children }: RenderElementProps) => (
+export const CodeElement = ({
+  attributes,
+  children,
+}: CodeRenderElementProps) => (
   <Pre>
     <code {...attributes}>{children}</code>
   </Pre>

--- a/packages/slate-plugins/src/elements/code/deserializeCode.ts
+++ b/packages/slate-plugins/src/elements/code/deserializeCode.ts
@@ -1,7 +1,9 @@
 import { DeserializeHtml } from 'common/types';
 import { getElementDeserializer } from 'element/utils';
-import { CODE } from './types';
+import { CODE, CodeDeserializeOptions } from './types';
 
-export const deserializeCode = ({ typeCode = CODE } = {}): DeserializeHtml => ({
+export const deserializeCode = ({
+  typeCode = CODE,
+}: CodeDeserializeOptions = {}): DeserializeHtml => ({
   element: getElementDeserializer(typeCode, { tagNames: ['PRE'] }),
 });

--- a/packages/slate-plugins/src/elements/code/renderElementCode.tsx
+++ b/packages/slate-plugins/src/elements/code/renderElementCode.tsx
@@ -1,11 +1,11 @@
-import { getRenderElement, RenderElementOptions } from 'element';
+import { getRenderElement } from 'element';
 import { CodeElement } from './components';
-import { CODE } from './types';
+import { CODE, CodeRenderElementOptions } from './types';
 
 export const renderElementCode = ({
   typeCode = CODE,
   component = CodeElement,
-}: RenderElementOptions = {}) =>
+}: CodeRenderElementOptions = {}) =>
   getRenderElement({
     type: typeCode,
     component,

--- a/packages/slate-plugins/src/elements/code/types.ts
+++ b/packages/slate-plugins/src/elements/code/types.ts
@@ -1,15 +1,13 @@
-import { TemplateDeserializeOptions } from '__templates__/types-element.template';
 import { RenderElementOptions } from 'element';
 import { Element } from 'slate';
 import { RenderElementProps } from 'slate-react';
 
 export const CODE = 'code';
 
-export interface CodeNodeData {
-  [key: string]: unknown;
-}
+// Data of Element node
+export interface CodeNodeData {}
 
-// Node
+// Element node
 export interface CodeNode extends Element, CodeNodeData {}
 
 // Option type

--- a/packages/slate-plugins/src/elements/code/types.ts
+++ b/packages/slate-plugins/src/elements/code/types.ts
@@ -1,1 +1,42 @@
+import { TemplateDeserializeOptions } from '__templates__/types-element.template';
+import { RenderElementOptions } from 'element';
+import { Element } from 'slate';
+import { RenderElementProps } from 'slate-react';
+
 export const CODE = 'code';
+
+export interface CodeNodeData {
+  [key: string]: unknown;
+}
+
+// Node
+export interface CodeNode extends Element, CodeNodeData {}
+
+// Option type
+interface TypeOption {
+  typeCode?: string;
+}
+
+// deserialize options
+export interface CodeDeserializeOptions extends TypeOption {}
+
+// renderElement options given as props
+interface CodeRenderElementOptionsProps {}
+
+// renderElement options
+export interface CodeRenderElementOptions
+  extends RenderElementOptions,
+    CodeRenderElementOptionsProps,
+    TypeOption {}
+
+// renderElement props
+export interface CodeRenderElementProps
+  extends RenderElementProps,
+    CodeRenderElementOptionsProps {
+  element: CodeNode;
+}
+
+// Plugin options
+export interface CodePluginOptions
+  extends CodeRenderElementOptions,
+    CodeDeserializeOptions {}

--- a/packages/slate-plugins/src/elements/heading/components/HeadingElements.tsx
+++ b/packages/slate-plugins/src/elements/heading/components/HeadingElements.tsx
@@ -1,0 +1,68 @@
+import styled from 'styled-components';
+
+export interface HeadingElementProps {
+  fontSize: number;
+}
+
+const baseMargin = 4.8;
+
+const HeadingElement = styled.div<HeadingElementProps>`
+  font-weight: 400;
+`;
+
+export const HeadingElement1 = styled(HeadingElement)`
+  :not(:first-child) {
+    margin-top: 30px;
+  }
+  margin-bottom: ${baseMargin * 2.5}px;
+  font-size: ${({ fontSize }) => (fontSize * 20) / 11}px;
+  line-height: 36px;
+`;
+
+export const HeadingElement2 = styled(HeadingElement)`
+  :not(:first-child) {
+    margin-top: 18px;
+  }
+  margin-bottom: ${baseMargin * 1.5}px;
+  font-size: ${({ fontSize }) => (fontSize * 16) / 11}px;
+  line-height: 28px;
+`;
+
+export const HeadingElement3 = styled(HeadingElement)`
+  color: #434343;
+  :not(:first-child) {
+    margin-top: 8px;
+  }
+  margin-bottom: ${baseMargin * 1.25}px;
+  font-size: ${({ fontSize }) => (fontSize * 14) / 11}px;
+`;
+
+export const HeadingElement4 = styled(HeadingElement)`
+  color: #666666;
+  :not(:first-child) {
+    margin-top: 8px;
+  }
+  margin-bottom: ${baseMargin}px;
+  font-size: ${({ fontSize }) => (fontSize * 12) / 11}px;
+`;
+
+export const HeadingElement5 = styled(HeadingElement)`
+  color: #666666;
+
+  :not(:first-child) {
+    margin-top: 8px;
+  }
+  margin-bottom: ${baseMargin}px;
+  font-size: ${({ fontSize }) => fontSize}px;
+`;
+
+export const HeadingElement6 = styled(HeadingElement)`
+  color: #666666;
+  font-style: italic;
+
+  :not(:first-child) {
+    margin-top: 8px;
+  }
+  margin-bottom: ${baseMargin}px;
+  font-size: ${({ fontSize }) => fontSize}px;
+`;

--- a/packages/slate-plugins/src/elements/heading/components/index.ts
+++ b/packages/slate-plugins/src/elements/heading/components/index.ts
@@ -1,0 +1,1 @@
+export * from './HeadingElements';

--- a/packages/slate-plugins/src/elements/heading/deserializeHeading.ts
+++ b/packages/slate-plugins/src/elements/heading/deserializeHeading.ts
@@ -1,6 +1,6 @@
 import { DeserializeHtml } from 'common/types';
 import { getElementDeserializer } from 'element/utils';
-import { DeserializeHeadingOptions, HeadingType } from './types';
+import { HeadingDeserializeOptions, HeadingType } from './types';
 
 export const deserializeHeading = ({
   levels = 6,
@@ -10,7 +10,7 @@ export const deserializeHeading = ({
   typeH4 = HeadingType.H4,
   typeH5 = HeadingType.H5,
   typeH6 = HeadingType.H6,
-}: DeserializeHeadingOptions = {}): DeserializeHtml => {
+}: HeadingDeserializeOptions = {}): DeserializeHtml => {
   let headingTags = getElementDeserializer(typeH1, { tagNames: ['H1'] });
 
   if (levels >= 2)

--- a/packages/slate-plugins/src/elements/heading/index.ts
+++ b/packages/slate-plugins/src/elements/heading/index.ts
@@ -2,3 +2,4 @@ export * from './deserializeHeading';
 export * from './HeadingPlugin';
 export * from './renderElementHeading';
 export * from './types';
+export * from './components';

--- a/packages/slate-plugins/src/elements/heading/renderElementHeading.tsx
+++ b/packages/slate-plugins/src/elements/heading/renderElementHeading.tsx
@@ -1,75 +1,15 @@
 import React from 'react';
 import { getElementComponent } from 'element/utils';
+import {
+  HeadingElement1,
+  HeadingElement2,
+  HeadingElement3,
+  HeadingElement4,
+  HeadingElement5,
+  HeadingElement6,
+} from 'elements/heading/components/HeadingElements';
 import { RenderElementProps } from 'slate-react';
-import styled from 'styled-components';
-import { HeadingType, RenderElementHeadingOptions } from './types';
-
-export interface HeadingProps {
-  fontSize: number;
-}
-
-const baseMargin = 4.8;
-
-const Heading = styled.div<HeadingProps>`
-  font-weight: 400;
-`;
-
-const StyledH1 = styled(Heading)`
-  :not(:first-child) {
-    margin-top: 30px;
-  }
-  margin-bottom: ${baseMargin * 2.5}px;
-  font-size: ${({ fontSize }) => (fontSize * 20) / 11}px;
-  line-height: 36px;
-`;
-
-const StyledH2 = styled(Heading)`
-  :not(:first-child) {
-    margin-top: 18px;
-  }
-  margin-bottom: ${baseMargin * 1.5}px;
-  font-size: ${({ fontSize }) => (fontSize * 16) / 11}px;
-  line-height: 28px;
-`;
-
-const StyledH3 = styled(Heading)`
-  color: #434343;
-  :not(:first-child) {
-    margin-top: 8px;
-  }
-  margin-bottom: ${baseMargin * 1.25}px;
-  font-size: ${({ fontSize }) => (fontSize * 14) / 11}px;
-`;
-
-const StyledH4 = styled(Heading)`
-  color: #666666;
-  :not(:first-child) {
-    margin-top: 8px;
-  }
-  margin-bottom: ${baseMargin}px;
-  font-size: ${({ fontSize }) => (fontSize * 12) / 11}px;
-`;
-
-const StyledH5 = styled(Heading)`
-  color: #666666;
-
-  :not(:first-child) {
-    margin-top: 8px;
-  }
-  margin-bottom: ${baseMargin}px;
-  font-size: ${({ fontSize }) => fontSize}px;
-`;
-
-const StyledH6 = styled(Heading)`
-  color: #666666;
-  font-style: italic;
-
-  :not(:first-child) {
-    margin-top: 8px;
-  }
-  margin-bottom: ${baseMargin}px;
-  font-size: ${({ fontSize }) => fontSize}px;
-`;
+import { HeadingRenderElementOptions, HeadingType } from './types';
 
 /**
  * Font sizes are relative to the base font size
@@ -87,15 +27,15 @@ export const renderElementHeading = ({
   typeH4 = HeadingType.H4,
   typeH5 = HeadingType.H5,
   typeH6 = HeadingType.H6,
-  H1 = getElementComponent(StyledH1),
-  H2 = getElementComponent(StyledH2),
-  H3 = getElementComponent(StyledH3),
-  H4 = getElementComponent(StyledH4),
-  H5 = getElementComponent(StyledH5),
-  H6 = getElementComponent(StyledH6),
+  H1 = getElementComponent(HeadingElement1),
+  H2 = getElementComponent(HeadingElement2),
+  H3 = getElementComponent(HeadingElement3),
+  H4 = getElementComponent(HeadingElement4),
+  H5 = getElementComponent(HeadingElement5),
+  H6 = getElementComponent(HeadingElement6),
   levels = 6,
   fontSize = 16,
-}: RenderElementHeadingOptions = {}) => (props: RenderElementProps) => {
+}: HeadingRenderElementOptions = {}) => (props: RenderElementProps) => {
   const {
     element: { type },
   } = props;

--- a/packages/slate-plugins/src/elements/heading/types.ts
+++ b/packages/slate-plugins/src/elements/heading/types.ts
@@ -11,11 +11,10 @@ export enum HeadingType {
   H6 = 'h6',
 }
 
-export interface HeadingNodeData {
-  [key: string]: unknown;
-}
+// Data of Element node
+export interface HeadingNodeData {}
 
-// Node
+// Element node
 export interface HeadingNode extends Element, HeadingNodeData {}
 
 // Option type

--- a/packages/slate-plugins/src/elements/heading/types.ts
+++ b/packages/slate-plugins/src/elements/heading/types.ts
@@ -1,3 +1,7 @@
+import { RenderElementOptions } from 'element';
+import { Element } from 'slate';
+import { RenderElementProps } from 'slate-react';
+
 export enum HeadingType {
   H1 = 'h1',
   H2 = 'h2',
@@ -7,7 +11,15 @@ export enum HeadingType {
   H6 = 'h6',
 }
 
-export interface HeadingTypeOptions {
+export interface HeadingNodeData {
+  [key: string]: unknown;
+}
+
+// Node
+export interface HeadingNode extends Element, HeadingNodeData {}
+
+// Option type
+interface TypeOption {
   typeH1?: string;
   typeH2?: string;
   typeH3?: string;
@@ -16,11 +28,22 @@ export interface HeadingTypeOptions {
   typeH6?: string;
 }
 
-export interface DeserializeHeadingOptions extends HeadingTypeOptions {
+interface OptionLevels {
   levels?: number;
 }
 
-export interface RenderElementHeadingOptions extends DeserializeHeadingOptions {
+// deserialize options
+export interface HeadingDeserializeOptions extends TypeOption, OptionLevels {}
+
+// renderElement options given as props
+interface HeadingRenderElementOptionsProps {}
+
+// renderElement options
+export interface HeadingRenderElementOptions
+  extends RenderElementOptions,
+    HeadingRenderElementOptionsProps,
+    TypeOption,
+    OptionLevels {
   H1?: any;
   H2?: any;
   H3?: any;
@@ -30,4 +53,14 @@ export interface RenderElementHeadingOptions extends DeserializeHeadingOptions {
   fontSize?: number;
 }
 
-export interface HeadingPluginOptions extends RenderElementHeadingOptions {}
+// renderElement props
+export interface HeadingRenderElementProps
+  extends RenderElementProps,
+    HeadingRenderElementOptionsProps {
+  element: HeadingNode;
+}
+
+// Plugin options
+export interface HeadingPluginOptions
+  extends HeadingRenderElementOptions,
+    HeadingDeserializeOptions {}

--- a/packages/slate-plugins/src/elements/image/ImagePlugin.ts
+++ b/packages/slate-plugins/src/elements/image/ImagePlugin.ts
@@ -1,11 +1,9 @@
 import { SlatePlugin } from 'common/types';
-import { RenderElementOptions } from 'element';
 import { renderElementImage } from 'elements/image/renderElementImage';
+import { ImagePluginOptions } from 'elements/image/types';
 import { deserializeImage } from './deserializeImage';
 
-export const ImagePlugin = (
-  options?: RenderElementOptions & { typeImg?: string }
-): SlatePlugin => ({
+export const ImagePlugin = (options?: ImagePluginOptions): SlatePlugin => ({
   renderElement: renderElementImage(options),
   deserialize: deserializeImage(options),
 });

--- a/packages/slate-plugins/src/elements/image/components/ImageElement.tsx
+++ b/packages/slate-plugins/src/elements/image/components/ImageElement.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { RenderElementProps, useFocused, useSelected } from 'slate-react';
+import { ImageRenderElementProps } from 'elements/image/types';
+import { useFocused, useSelected } from 'slate-react';
 import styled from 'styled-components';
 
 const Image = styled.img<{ selected: boolean; focused: boolean }>`
@@ -15,8 +16,8 @@ export const ImageElement = ({
   attributes,
   children,
   element,
-}: RenderElementProps) => {
-  const url = element.url as string;
+}: ImageRenderElementProps) => {
+  const { url } = element;
   const selected = useSelected();
   const focused = useFocused();
 

--- a/packages/slate-plugins/src/elements/image/deserializeImage.ts
+++ b/packages/slate-plugins/src/elements/image/deserializeImage.ts
@@ -1,10 +1,10 @@
 import { DeserializeHtml } from 'common/types';
 import { getElementDeserializer } from 'element/utils';
-import { IMAGE } from './types';
+import { IMAGE, ImageDeserializeOptions } from './types';
 
 export const deserializeImage = ({
   typeImg = IMAGE,
-} = {}): DeserializeHtml => ({
+}: ImageDeserializeOptions = {}): DeserializeHtml => ({
   element: getElementDeserializer(typeImg, {
     tagNames: ['IMG'],
     createElement: (el) => ({

--- a/packages/slate-plugins/src/elements/image/index.ts
+++ b/packages/slate-plugins/src/elements/image/index.ts
@@ -5,4 +5,3 @@ export * from './transforms';
 export * from './types';
 export * from './utils';
 export * from './withImage';
-export { onImageLoad } from 'elements/image/utils/onImageLoad';

--- a/packages/slate-plugins/src/elements/image/index.ts
+++ b/packages/slate-plugins/src/elements/image/index.ts
@@ -5,3 +5,4 @@ export * from './transforms';
 export * from './types';
 export * from './utils';
 export * from './withImage';
+export { onImageLoad } from 'elements/image/utils/onImageLoad';

--- a/packages/slate-plugins/src/elements/image/renderElementImage.ts
+++ b/packages/slate-plugins/src/elements/image/renderElementImage.ts
@@ -1,11 +1,11 @@
-import { getRenderElement, RenderElementOptions } from 'element';
+import { getRenderElement } from 'element';
 import { ImageElement } from './components';
-import { IMAGE } from './types';
+import { IMAGE, ImageRenderElementOptions } from './types';
 
 export const renderElementImage = ({
   typeImg = IMAGE,
   component = ImageElement,
-}: RenderElementOptions = {}) =>
+}: ImageRenderElementOptions = {}) =>
   getRenderElement({
     type: typeImg,
     component,

--- a/packages/slate-plugins/src/elements/image/types.ts
+++ b/packages/slate-plugins/src/elements/image/types.ts
@@ -1,1 +1,44 @@
+import { RenderElementOptions } from 'element';
+import { Element } from 'slate';
+import { RenderElementProps } from 'slate-react';
+
 export const IMAGE = 'img';
+
+export interface ImageNodeData {
+  url: string;
+  [key: string]: unknown;
+}
+
+// Node
+export interface ImageNode extends Element, ImageNodeData {}
+
+// Option type
+interface TypeOption {
+  typeImg?: string;
+}
+
+// deserialize options
+export interface ImageDeserializeOptions extends TypeOption {}
+
+// renderElement options given as props
+interface ImageRenderElementOptionsProps {}
+
+// renderElement options
+export interface ImageRenderElementOptions
+  extends RenderElementOptions,
+    ImageRenderElementOptionsProps,
+    TypeOption {}
+
+// renderElement props
+export interface ImageRenderElementProps
+  extends RenderElementProps,
+    ImageRenderElementOptionsProps {
+  element: ImageNode;
+}
+
+// Plugin options
+export interface ImagePluginOptions
+  extends ImageRenderElementOptions,
+    ImageDeserializeOptions {}
+
+export interface WithImageOptions extends TypeOption {}

--- a/packages/slate-plugins/src/elements/image/types.ts
+++ b/packages/slate-plugins/src/elements/image/types.ts
@@ -4,12 +4,12 @@ import { RenderElementProps } from 'slate-react';
 
 export const IMAGE = 'img';
 
+// Data of Element node
 export interface ImageNodeData {
   url: string;
-  [key: string]: unknown;
 }
 
-// Node
+// Element node
 export interface ImageNode extends Element, ImageNodeData {}
 
 // Option type

--- a/packages/slate-plugins/src/elements/image/utils/index.ts
+++ b/packages/slate-plugins/src/elements/image/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './isImageUrl';
+export * from './onImageLoad';

--- a/packages/slate-plugins/src/elements/image/utils/onImageLoad.ts
+++ b/packages/slate-plugins/src/elements/image/utils/onImageLoad.ts
@@ -1,0 +1,7 @@
+import { insertImage } from 'elements/image/transforms';
+import { ReactEditor } from 'slate-react';
+
+export const onImageLoad = (editor: ReactEditor, reader: FileReader) => () => {
+  const url = reader.result;
+  if (url) insertImage(editor, url);
+};

--- a/packages/slate-plugins/src/elements/image/withImage.ts
+++ b/packages/slate-plugins/src/elements/image/withImage.ts
@@ -1,15 +1,13 @@
 import { withVoid } from 'element';
+import { onImageLoad } from 'elements/image/utils/onImageLoad';
 import { ReactEditor } from 'slate-react';
 import { isImageUrl } from './utils/isImageUrl';
 import { insertImage } from './transforms';
-import { IMAGE } from './types';
+import { IMAGE, WithImageOptions } from './types';
 
-export const onImageLoad = (editor: ReactEditor, reader: FileReader) => () => {
-  const url = reader.result;
-  if (url) insertImage(editor, url);
-};
-
-export const withImage = ({ typeImg = IMAGE } = {}) => <T extends ReactEditor>(
+export const withImage = ({ typeImg = IMAGE }: WithImageOptions = {}) => <
+  T extends ReactEditor
+>(
   editor: T
 ) => {
   editor = withVoid([typeImg])(editor);

--- a/packages/slate-plugins/src/elements/link/LinkPlugin.ts
+++ b/packages/slate-plugins/src/elements/link/LinkPlugin.ts
@@ -1,11 +1,9 @@
 import { SlatePlugin } from 'common/types';
-import { RenderElementOptions } from 'element';
+import { LinkPluginOptions } from 'elements/link/types';
 import { deserializeLink } from './deserializeLink';
 import { renderElementLink } from './renderElementLink';
 
-export const LinkPlugin = (
-  options?: RenderElementOptions & { typeLink?: string }
-): SlatePlugin => ({
+export const LinkPlugin = (options?: LinkPluginOptions): SlatePlugin => ({
   renderElement: renderElementLink(options),
   deserialize: deserializeLink(options),
 });

--- a/packages/slate-plugins/src/elements/link/components/LinkElement.tsx
+++ b/packages/slate-plugins/src/elements/link/components/LinkElement.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { RenderElementProps } from 'slate-react';
+import { LinkRenderElementProps } from 'elements/link/types';
 
 export const LinkElement = ({
   attributes,
   children,
   element,
-}: RenderElementProps) => (
-  <a {...attributes} href={element.url as string}>
+}: LinkRenderElementProps) => (
+  <a {...attributes} href={element.url}>
     {children}
   </a>
 );

--- a/packages/slate-plugins/src/elements/link/deserializeLink.ts
+++ b/packages/slate-plugins/src/elements/link/deserializeLink.ts
@@ -1,8 +1,10 @@
 import { DeserializeHtml } from 'common/types';
 import { getElementDeserializer } from 'element/utils';
-import { LINK } from './types';
+import { LINK, LinkDeserializeOptions } from './types';
 
-export const deserializeLink = ({ typeLink = LINK } = {}): DeserializeHtml => ({
+export const deserializeLink = ({
+  typeLink = LINK,
+}: LinkDeserializeOptions = {}): DeserializeHtml => ({
   element: {
     ...getElementDeserializer(typeLink, {
       tagNames: ['A'],

--- a/packages/slate-plugins/src/elements/link/renderElementLink.ts
+++ b/packages/slate-plugins/src/elements/link/renderElementLink.ts
@@ -1,11 +1,11 @@
-import { getRenderElement, RenderElementOptions } from 'element';
+import { getRenderElement } from 'element';
 import { LinkElement } from './components';
-import { LINK } from './types';
+import { LINK, LinkRenderElementOptions } from './types';
 
 export const renderElementLink = ({
   typeLink = LINK,
   component = LinkElement,
-}: RenderElementOptions = {}) =>
+}: LinkRenderElementOptions = {}) =>
   getRenderElement({
     type: typeLink,
     component,

--- a/packages/slate-plugins/src/elements/link/types.ts
+++ b/packages/slate-plugins/src/elements/link/types.ts
@@ -4,12 +4,12 @@ import { RenderElementProps } from 'slate-react';
 
 export const LINK = 'a';
 
+// Data of Element node
 export interface LinkNodeData {
   url: string;
-  [key: string]: unknown;
 }
 
-// Node
+// Element node
 export interface LinkNode extends Element, LinkNodeData {}
 
 // Option type

--- a/packages/slate-plugins/src/elements/link/types.ts
+++ b/packages/slate-plugins/src/elements/link/types.ts
@@ -1,1 +1,44 @@
+import { RenderElementOptions } from 'element';
+import { Element } from 'slate';
+import { RenderElementProps } from 'slate-react';
+
 export const LINK = 'a';
+
+export interface LinkNodeData {
+  url: string;
+  [key: string]: unknown;
+}
+
+// Node
+export interface LinkNode extends Element, LinkNodeData {}
+
+// Option type
+interface TypeOption {
+  typeLink?: string;
+}
+
+// deserialize options
+export interface LinkDeserializeOptions extends TypeOption {}
+
+// renderElement options given as props
+interface LinkRenderElementOptionsProps {}
+
+// renderElement options
+export interface LinkRenderElementOptions
+  extends RenderElementOptions,
+    LinkRenderElementOptionsProps,
+    TypeOption {}
+
+// renderElement props
+export interface LinkRenderElementProps
+  extends RenderElementProps,
+    LinkRenderElementOptionsProps {
+  element: LinkNode;
+}
+
+// Plugin options
+export interface LinkPluginOptions
+  extends LinkRenderElementOptions,
+    LinkDeserializeOptions {}
+
+export interface WithLinkOptions extends TypeOption {}

--- a/packages/slate-plugins/src/elements/link/withLink.ts
+++ b/packages/slate-plugins/src/elements/link/withLink.ts
@@ -2,9 +2,11 @@ import { isUrl } from 'common/utils';
 import { withInline } from 'element';
 import { ReactEditor } from 'slate-react';
 import { wrapLink } from './transforms';
-import { LINK } from './types';
+import { LINK, WithLinkOptions } from './types';
 
-export const withLink = ({ typeLink = LINK } = {}) => <T extends ReactEditor>(
+export const withLink = ({ typeLink = LINK }: WithLinkOptions = {}) => <
+  T extends ReactEditor
+>(
   editor: T
 ) => {
   editor = withInline([typeLink])(editor);

--- a/packages/slate-plugins/src/elements/list/ListPlugin.ts
+++ b/packages/slate-plugins/src/elements/list/ListPlugin.ts
@@ -2,11 +2,9 @@ import { SlatePlugin } from 'common/types';
 import { deserializeList } from './deserializeList';
 import { onKeyDownList } from './onKeyDownList';
 import { renderElementList } from './renderElementList';
-import { RenderElementListOptions } from './types';
+import { ListPluginOptions } from './types';
 
-export const ListPlugin = (
-  options?: RenderElementListOptions
-): SlatePlugin => ({
+export const ListPlugin = (options?: ListPluginOptions): SlatePlugin => ({
   renderElement: renderElementList(options),
   deserialize: deserializeList(options),
   onKeyDown: onKeyDownList(options),

--- a/packages/slate-plugins/src/elements/list/components/ListElements.tsx
+++ b/packages/slate-plugins/src/elements/list/components/ListElements.tsx
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+
+export const UlElement = styled.ul`
+  padding-inline-start: 24px;
+  margin-block-start: 0;
+  margin-block-end: 0;
+`;
+
+export const OlElement = styled.ol`
+  padding-inline-start: 24px;
+  margin-block-start: 0;
+  margin-block-end: 0;
+`;

--- a/packages/slate-plugins/src/elements/list/components/index.ts
+++ b/packages/slate-plugins/src/elements/list/components/index.ts
@@ -1,1 +1,2 @@
 export * from './ToolbarList';
+export * from './ListElements';

--- a/packages/slate-plugins/src/elements/list/deserializeList.ts
+++ b/packages/slate-plugins/src/elements/list/deserializeList.ts
@@ -1,12 +1,12 @@
 import { DeserializeHtml } from 'common/types';
 import { getElementDeserializer } from 'element/utils';
-import { ListType, ListTypeOptions } from './types';
+import { ListDeserializeOptions, ListType } from './types';
 
 export const deserializeList = ({
   typeUl = ListType.UL,
   typeOl = ListType.OL,
   typeLi = ListType.LI,
-}: ListTypeOptions = {}): DeserializeHtml => ({
+}: ListDeserializeOptions = {}): DeserializeHtml => ({
   element: {
     ...getElementDeserializer(typeUl, { tagNames: ['UL'] }),
     ...getElementDeserializer(typeOl, { tagNames: ['OL'] }),

--- a/packages/slate-plugins/src/elements/list/index.ts
+++ b/packages/slate-plugins/src/elements/list/index.ts
@@ -7,3 +7,5 @@ export * from './renderElementList';
 export * from './transforms';
 export * from './types';
 export * from './withList';
+export { OlElement } from 'elements/list/components/ListElements';
+export { UlElement } from 'elements/list/components/ListElements';

--- a/packages/slate-plugins/src/elements/list/index.ts
+++ b/packages/slate-plugins/src/elements/list/index.ts
@@ -7,5 +7,3 @@ export * from './renderElementList';
 export * from './transforms';
 export * from './types';
 export * from './withList';
-export { OlElement } from 'elements/list/components/ListElements';
-export { UlElement } from 'elements/list/components/ListElements';

--- a/packages/slate-plugins/src/elements/list/onKeyDownList.ts
+++ b/packages/slate-plugins/src/elements/list/onKeyDownList.ts
@@ -10,8 +10,8 @@ import { isList } from './queries';
 import {
   defaultListTypes,
   ListHotkey,
+  ListOnKeyDownOptions,
   ListType,
-  ListTypeOptions,
 } from './types';
 
 /**
@@ -123,7 +123,7 @@ export const onKeyDownList = ({
   typeOl = ListType.OL,
   typeLi = ListType.LI,
   typeP = PARAGRAPH,
-}: ListTypeOptions = {}) => (e: KeyboardEvent, editor: Editor) => {
+}: ListOnKeyDownOptions = {}) => (e: KeyboardEvent, editor: Editor) => {
   const options = { typeUl, typeOl, typeLi, typeP };
 
   if (Object.values(ListHotkey).includes(e.key)) {

--- a/packages/slate-plugins/src/elements/list/renderElementList.tsx
+++ b/packages/slate-plugins/src/elements/list/renderElementList.tsx
@@ -1,18 +1,6 @@
 import { getElementComponent, getRenderElements } from 'element/utils';
-import styled from 'styled-components';
-import { ListType, RenderElementListOptions } from './types';
-
-const UlElement = styled.ul`
-  padding-inline-start: 24px;
-  margin-block-start: 0;
-  margin-block-end: 0;
-`;
-
-const OlElement = styled.ol`
-  padding-inline-start: 24px;
-  margin-block-start: 0;
-  margin-block-end: 0;
-`;
+import { OlElement, UlElement } from 'elements/list/components/ListElements';
+import { ListRenderElementOptions, ListType } from './types';
 
 export const renderElementList = ({
   UL = getElementComponent(UlElement),
@@ -21,7 +9,7 @@ export const renderElementList = ({
   typeUl = ListType.UL,
   typeOl = ListType.OL,
   typeLi = ListType.LI,
-}: RenderElementListOptions = {}) =>
+}: ListRenderElementOptions = {}) =>
   getRenderElements([
     { type: typeUl, component: UL },
     { type: typeOl, component: OL },

--- a/packages/slate-plugins/src/elements/list/types.ts
+++ b/packages/slate-plugins/src/elements/list/types.ts
@@ -1,4 +1,3 @@
-import { OnKeyDown } from 'common';
 import { PARAGRAPH } from 'elements/paragraph';
 import { Element } from 'slate';
 import { RenderElementProps } from 'slate-react';
@@ -22,11 +21,10 @@ export const defaultListTypes: TypeOption = {
   typeP: PARAGRAPH,
 };
 
-export interface ListNodeData {
-  [key: string]: unknown;
-}
+// Data of Element node
+export interface ListNodeData {}
 
-// Node
+// Element node
 export interface ListNode extends Element, ListNodeData {}
 
 // Option type

--- a/packages/slate-plugins/src/elements/list/types.ts
+++ b/packages/slate-plugins/src/elements/list/types.ts
@@ -1,4 +1,7 @@
+import { OnKeyDown } from 'common';
 import { PARAGRAPH } from 'elements/paragraph';
+import { Element } from 'slate';
+import { RenderElementProps } from 'slate-react';
 
 export const ListHotkey = {
   TAB: 'Tab',
@@ -12,22 +15,56 @@ export enum ListType {
   LI = 'li',
 }
 
-export interface ListTypeOptions {
+export const defaultListTypes: TypeOption = {
+  typeUl: ListType.UL,
+  typeOl: ListType.OL,
+  typeLi: ListType.LI,
+  typeP: PARAGRAPH,
+};
+
+export interface ListNodeData {
+  [key: string]: unknown;
+}
+
+// Node
+export interface ListNode extends Element, ListNodeData {}
+
+// Option type
+interface TypeOption {
   typeUl?: string;
   typeOl?: string;
   typeLi?: string;
   typeP?: string;
 }
 
-export interface RenderElementListOptions extends ListTypeOptions {
+// deserialize options
+export interface ListDeserializeOptions extends TypeOption {}
+
+// renderElement options given as props
+interface ListRenderElementOptionsProps {}
+
+// renderElement options
+export interface ListRenderElementOptions
+  extends ListRenderElementOptionsProps,
+    TypeOption {
   UL?: any;
   OL?: any;
   LI?: any;
 }
 
-export const defaultListTypes: ListTypeOptions = {
-  typeUl: ListType.UL,
-  typeOl: ListType.OL,
-  typeLi: ListType.LI,
-  typeP: PARAGRAPH,
-};
+// renderElement props
+export interface ListRenderElementProps
+  extends RenderElementProps,
+    ListRenderElementOptionsProps {
+  element: ListNode;
+}
+
+export interface ListOnKeyDownOptions extends TypeOption {}
+
+// Plugin options
+export interface ListPluginOptions
+  extends ListRenderElementOptions,
+    ListDeserializeOptions,
+    ListOnKeyDownOptions {}
+
+export interface WithListOptions extends TypeOption {}

--- a/packages/slate-plugins/src/elements/list/withList.ts
+++ b/packages/slate-plugins/src/elements/list/withList.ts
@@ -3,14 +3,14 @@ import { unwrapNodesByType } from 'common/transforms';
 import { withBreakEmptyReset, withDeleteStartReset } from 'element';
 import { PARAGRAPH } from 'elements/paragraph';
 import { Editor, Path, Point, Range, Transforms } from 'slate';
-import { ListType, ListTypeOptions } from './types';
+import { ListType, WithListOptions } from './types';
 
 export const withList = ({
   typeUl = ListType.UL,
   typeOl = ListType.OL,
   typeLi = ListType.LI,
   typeP = PARAGRAPH,
-}: ListTypeOptions = {}) => <T extends Editor>(editor: T) => {
+}: WithListOptions = {}) => <T extends Editor>(editor: T) => {
   const options = {
     typeUl,
     typeOl,

--- a/packages/slate-plugins/src/elements/mention/MentionPlugin.ts
+++ b/packages/slate-plugins/src/elements/mention/MentionPlugin.ts
@@ -1,11 +1,9 @@
 import { SlatePlugin } from 'common/types';
-import { RenderElementOptions } from 'element';
 import { deserializeMention } from 'elements/mention/deserializeMention';
 import { renderElementMention } from 'elements/mention/renderElementMention';
+import { MentionPluginOptions } from 'elements/mention/types';
 
-export const MentionPlugin = (
-  options?: RenderElementOptions & { typeMention: string }
-): SlatePlugin => ({
+export const MentionPlugin = (options?: MentionPluginOptions): SlatePlugin => ({
   renderElement: renderElementMention(options),
   deserialize: deserializeMention(options),
 });

--- a/packages/slate-plugins/src/elements/mention/components/MentionElement.tsx
+++ b/packages/slate-plugins/src/elements/mention/components/MentionElement.tsx
@@ -6,6 +6,7 @@ export const MentionElement = ({
   attributes,
   children,
   element,
+  prefix,
 }: MentionRenderElementProps) => {
   const selected = useSelected();
   const focused = useFocused();
@@ -13,7 +14,7 @@ export const MentionElement = ({
   return (
     <span
       {...attributes}
-      data-slate-character={element.mentionable.value}
+      data-slate-value={element.value}
       contentEditable={false}
       style={{
         padding: '3px 3px 2px',
@@ -26,8 +27,8 @@ export const MentionElement = ({
         boxShadow: selected && focused ? '0 0 0 2px #B4D5FF' : 'none',
       }}
     >
-      {element.prefix}
-      {element.mentionable.value}
+      {prefix}
+      {element.value}
       {children}
     </span>
   );

--- a/packages/slate-plugins/src/elements/mention/components/MentionSelect.styles.ts
+++ b/packages/slate-plugins/src/elements/mention/components/MentionSelect.styles.ts
@@ -1,0 +1,36 @@
+import { IStyle } from '@uifabric/styling';
+import { MentionSelectStyles } from 'elements/mention/components/MentionSelect.types';
+
+export const getStyles = (): MentionSelectStyles => {
+  const mentionItem: IStyle = [
+    {
+      padding: '1px 3px',
+      borderRadius: '3px',
+      background: 'transparent',
+    },
+  ];
+
+  const mentionItemSelected: IStyle = [
+    ...mentionItem,
+    {
+      background: '#B4D5FF',
+    },
+  ];
+
+  return {
+    root: [
+      {
+        top: '-9999px',
+        left: '-9999px',
+        position: 'absolute',
+        zIndex: 1,
+        padding: '3px',
+        background: 'white',
+        borderRadius: '4px',
+        boxShadow: '0 1px 5px rgba(0,0,0,.2)',
+      },
+    ],
+    mentionItem,
+    mentionItemSelected,
+  };
+};

--- a/packages/slate-plugins/src/elements/mention/components/MentionSelect.tsx
+++ b/packages/slate-plugins/src/elements/mention/components/MentionSelect.tsx
@@ -1,60 +1,71 @@
 import React, { useEffect, useRef } from 'react';
+import { classNamesFunction, styled } from '@uifabric/utilities';
+import { getStyles } from 'elements/mention/components/MentionSelect.styles';
+import {
+  MentionSelectProps,
+  MentionSelectStyleProps,
+  MentionSelectStyles,
+} from 'elements/mention/components/MentionSelect.types';
 import { ReactEditor, useSlate } from 'slate-react';
 import { PortalBody } from 'components';
-import { MentionableItem } from '../types';
 
-export const MentionSelect = ({
-  target,
-  mentionables,
-  index,
-}: {
-  target: any;
-  mentionables: MentionableItem[];
-  index: number;
-}) => {
+const getClassNames = classNamesFunction<
+  MentionSelectStyleProps,
+  MentionSelectStyles
+>();
+
+export const MentionSelectBase = ({
+  at,
+  options,
+  valueIndex,
+  styles,
+  ...props
+}: MentionSelectProps) => {
+  const classNames = getClassNames(styles);
+
   const ref: any = useRef();
   const editor = useSlate();
 
   useEffect(() => {
-    if (target && mentionables.length > 0) {
+    if (at && options.length > 0) {
       const el = ref.current;
-      const domRange = ReactEditor.toDOMRange(editor, target);
+      const domRange = ReactEditor.toDOMRange(editor, at);
       const rect = domRange.getBoundingClientRect();
       if (el) {
         el.style.top = `${rect.top + window.pageYOffset + 24}px`;
         el.style.left = `${rect.left + window.pageXOffset}px`;
       }
     }
-  }, [mentionables.length, editor, target]);
+  }, [options.length, editor, at]);
+
+  if (!at || !options.length) {
+    return null;
+  }
 
   return (
     <PortalBody>
-      <div
-        ref={ref}
-        style={{
-          top: '-9999px',
-          left: '-9999px',
-          position: 'absolute',
-          zIndex: 1,
-          padding: '3px',
-          background: 'white',
-          borderRadius: '4px',
-          boxShadow: '0 1px 5px rgba(0,0,0,.2)',
-        }}
-      >
-        {mentionables.map((mentionable, i) => (
+      <div ref={ref} className={classNames.root} {...props}>
+        {options.map((option, i) => (
           <div
-            key={`${i}${mentionable.value}`}
-            style={{
-              padding: '1px 3px',
-              borderRadius: '3px',
-              background: i === index ? '#B4D5FF' : 'transparent',
-            }}
+            key={`${i}${option.value}`}
+            className={
+              i === valueIndex
+                ? classNames.mentionItemSelected
+                : classNames.mentionItem
+            }
           >
-            {mentionable.value}
+            {option.value}
           </div>
         ))}
       </div>
     </PortalBody>
   );
 };
+
+export const MentionSelect: React.FC<MentionSelectProps> = styled<
+  MentionSelectProps,
+  MentionSelectStyleProps,
+  MentionSelectStyles
+>(MentionSelectBase, getStyles, undefined, {
+  scope: 'MentionSelect',
+});

--- a/packages/slate-plugins/src/elements/mention/components/MentionSelect.types.ts
+++ b/packages/slate-plugins/src/elements/mention/components/MentionSelect.types.ts
@@ -1,5 +1,5 @@
 import { IStyle, IStyleFunctionOrObject } from '@uifabric/merge-styles';
-import { MentionableItem } from 'elements/mention/types';
+import { MentionNodeData } from 'elements/mention/types';
 import { Range } from 'slate';
 
 export interface MentionSelectProps {
@@ -10,7 +10,7 @@ export interface MentionSelectProps {
   /**
    * List of mentionable items
    */
-  options: MentionableItem[];
+  options: MentionNodeData[];
   /**
    * Index of the selected option
    */

--- a/packages/slate-plugins/src/elements/mention/components/MentionSelect.types.ts
+++ b/packages/slate-plugins/src/elements/mention/components/MentionSelect.types.ts
@@ -1,0 +1,30 @@
+import { IStyle, IStyleFunctionOrObject } from '@uifabric/merge-styles';
+import { MentionableItem } from 'elements/mention/types';
+import { Range } from 'slate';
+
+export interface MentionSelectProps {
+  /**
+   * Range from the mention trigger to the cursor
+   */
+  at: Range | null;
+  /**
+   * List of mentionable items
+   */
+  options: MentionableItem[];
+  /**
+   * Index of the selected option
+   */
+  valueIndex: number;
+  /**
+   * Call to provide customized styling that will layer on top of the variant rules.
+   */
+  styles?: IStyleFunctionOrObject<{}, MentionSelectStyles>;
+}
+
+export interface MentionSelectStyleProps {}
+
+export interface MentionSelectStyles {
+  root: IStyle;
+  mentionItem: IStyle;
+  mentionItemSelected: IStyle;
+}

--- a/packages/slate-plugins/src/elements/mention/deserializeMention.ts
+++ b/packages/slate-plugins/src/elements/mention/deserializeMention.ts
@@ -1,10 +1,10 @@
 import { DeserializeHtml } from 'common/types';
 import { getElementDeserializer } from 'element/utils';
-import { MENTION } from './types';
+import { MENTION, MentionDeserializeOptions } from './types';
 
 export const deserializeMention = ({
   typeMention = MENTION,
-} = {}): DeserializeHtml => ({
+}: MentionDeserializeOptions = {}): DeserializeHtml => ({
   element: getElementDeserializer(typeMention, {
     createElement: (el) => ({
       type: typeMention,

--- a/packages/slate-plugins/src/elements/mention/deserializeMention.ts
+++ b/packages/slate-plugins/src/elements/mention/deserializeMention.ts
@@ -8,7 +8,7 @@ export const deserializeMention = ({
   element: getElementDeserializer(typeMention, {
     createElement: (el) => ({
       type: typeMention,
-      character: el.getAttribute('data-slate-character'),
+      character: el.getAttribute('data-slate-value'),
     }),
   }),
 });

--- a/packages/slate-plugins/src/elements/mention/index.ts
+++ b/packages/slate-plugins/src/elements/mention/index.ts
@@ -6,3 +6,4 @@ export * from './types';
 export * from './useMention';
 export * from './withMention';
 export * from './deserializeMention';
+export * from './utils';

--- a/packages/slate-plugins/src/elements/mention/renderElementMention.ts
+++ b/packages/slate-plugins/src/elements/mention/renderElementMention.ts
@@ -1,12 +1,14 @@
-import { getRenderElement, RenderElementOptions } from 'element';
+import { getRenderElement } from 'element';
 import { MentionElement } from './components';
-import { MENTION } from './types';
+import { MENTION, MentionRenderElementOptions } from './types';
 
 export const renderElementMention = ({
   typeMention = MENTION,
   component = MentionElement,
-}: RenderElementOptions = {}) =>
+  prefix = '@',
+}: MentionRenderElementOptions = {}) =>
   getRenderElement({
     type: typeMention,
     component,
+    prefix,
   });

--- a/packages/slate-plugins/src/elements/mention/transforms/insertMention.ts
+++ b/packages/slate-plugins/src/elements/mention/transforms/insertMention.ts
@@ -1,16 +1,11 @@
 import { Editor, Transforms } from 'slate';
-import { MentionableItem, MentionNode } from '../types';
+import { MENTION, MentionableItem, MentionNode } from '../types';
 
-export const insertMention = (
-  editor: Editor,
-  mentionable: MentionableItem,
-  prefix: string
-) => {
+export const insertMention = (editor: Editor, mentionable: MentionableItem) => {
   const mention: MentionNode = {
-    type: 'mention',
-    prefix,
-    mentionable,
+    type: MENTION,
     children: [{ text: '' }],
+    ...mentionable,
   };
   Transforms.insertNodes(editor, mention);
   Transforms.move(editor);

--- a/packages/slate-plugins/src/elements/mention/transforms/insertMention.ts
+++ b/packages/slate-plugins/src/elements/mention/transforms/insertMention.ts
@@ -1,7 +1,7 @@
 import { Editor, Transforms } from 'slate';
-import { MENTION, MentionableItem, MentionNode } from '../types';
+import { MENTION, MentionNode, MentionNodeData } from '../types';
 
-export const insertMention = (editor: Editor, mentionable: MentionableItem) => {
+export const insertMention = (editor: Editor, mentionable: MentionNodeData) => {
   const mention: MentionNode = {
     type: MENTION,
     children: [{ text: '' }],

--- a/packages/slate-plugins/src/elements/mention/types.ts
+++ b/packages/slate-plugins/src/elements/mention/types.ts
@@ -12,13 +12,12 @@ export interface UseMentionOptions {
   maxSuggestions?: number;
 }
 
-// Node data
+// Data of Element node
 export interface MentionNodeData {
   value: string;
-  [key: string]: unknown;
 }
 
-// Node
+// Element node
 export interface MentionNode extends Element, MentionNodeData {}
 
 // Option type

--- a/packages/slate-plugins/src/elements/mention/types.ts
+++ b/packages/slate-plugins/src/elements/mention/types.ts
@@ -1,34 +1,37 @@
-import { Element, Node } from 'slate';
+import { RenderElementOptions } from 'element';
+import { Element } from 'slate';
 import { RenderElementProps } from 'slate-react';
 
 export const MENTION = 'mention';
 
-export interface OnKeyDownMentionOptions {
-  mentionables: MentionableItem[];
-  index: number;
-  target: any;
-  setIndex: any;
-  setTarget: any;
+export interface UseMentionOptions {
+  // Character triggering the mention select
+  trigger?: string;
+  // Maximum number of suggestions
+  maxSuggestions?: number;
 }
 
-export interface MentionOptions {
-  trigger: string;
-  prefix: string;
-  maxSuggestions: number;
+export interface MentionPluginOptions extends MentionRenderElementOptions {}
+
+export interface MentionRenderElementOptions extends RenderElementOptions {
+  typeMention?: string;
+  /**
+   * Prefix rendered before mention
+   */
+  prefix?: string;
 }
 
 export interface MentionableItem {
   value: string;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
-export interface MentionNode extends Element {
-  type: typeof MENTION;
-  prefix: string;
-  mentionable: MentionableItem;
-  children: Node[];
-}
+export interface MentionNode extends Element, MentionableItem {}
 
 export interface MentionRenderElementProps extends RenderElementProps {
   element: MentionNode;
+  /**
+   * Prefix rendered before mention
+   */
+  prefix?: string;
 }

--- a/packages/slate-plugins/src/elements/mention/types.ts
+++ b/packages/slate-plugins/src/elements/mention/types.ts
@@ -4,6 +4,7 @@ import { RenderElementProps } from 'slate-react';
 
 export const MENTION = 'mention';
 
+// useMention options
 export interface UseMentionOptions {
   // Character triggering the mention select
   trigger?: string;
@@ -11,21 +12,21 @@ export interface UseMentionOptions {
   maxSuggestions?: number;
 }
 
-export interface MentionableItem {
+// Node data
+export interface MentionNodeData {
   value: string;
   [key: string]: unknown;
 }
 
-export interface MentionNode extends Element, MentionableItem {}
+// Node
+export interface MentionNode extends Element, MentionNodeData {}
 
-export interface MentionPluginOptions extends MentionRenderElementOptions {}
-
-export interface MentionRenderElementOptions
-  extends RenderElementOptions,
-    MentionRenderElementOptionsProps {
+// Option type
+interface TypeOption {
   typeMention?: string;
 }
 
+// renderElement options given as props
 interface MentionRenderElementOptionsProps {
   /**
    * Prefix rendered before mention
@@ -34,8 +35,24 @@ interface MentionRenderElementOptionsProps {
   onClick?: ({ value }: { value: string }) => void;
 }
 
+// renderElement options
+export interface MentionRenderElementOptions
+  extends RenderElementOptions,
+    MentionRenderElementOptionsProps,
+    TypeOption {}
+
+// renderElement props
 export interface MentionRenderElementProps
   extends RenderElementProps,
     MentionRenderElementOptionsProps {
   element: MentionNode;
 }
+
+export interface MentionDeserializeOptions extends TypeOption {}
+
+// Plugin options
+export interface MentionPluginOptions
+  extends MentionRenderElementOptions,
+    MentionDeserializeOptions {}
+
+export interface WithMentionOptions extends TypeOption {}

--- a/packages/slate-plugins/src/elements/mention/useMention.tsx
+++ b/packages/slate-plugins/src/elements/mention/useMention.tsx
@@ -4,10 +4,10 @@ import { getNextIndex } from 'elements/mention/utils/getNextIndex';
 import { getPreviousIndex } from 'elements/mention/utils/getPreviousIndex';
 import { Editor, Range, Transforms } from 'slate';
 import { insertMention } from './transforms';
-import { MentionableItem, UseMentionOptions } from './types';
+import { MentionNodeData, UseMentionOptions } from './types';
 
 export const useMention = (
-  mentionables: MentionableItem[] = [],
+  mentionables: MentionNodeData[] = [],
   { maxSuggestions = 10, trigger = '@' }: UseMentionOptions = {}
 ) => {
   const [targetRange, setTargetRange] = useState<Range | null>(null);

--- a/packages/slate-plugins/src/elements/mention/useMention.tsx
+++ b/packages/slate-plugins/src/elements/mention/useMention.tsx
@@ -22,22 +22,22 @@ export const useMention = (
       if (targetRange) {
         if (e.key === 'ArrowDown') {
           e.preventDefault();
-          setValueIndex(getNextIndex(valueIndex, values.length - 1));
+          return setValueIndex(getNextIndex(valueIndex, values.length - 1));
         }
         if (e.key === 'ArrowUp') {
           e.preventDefault();
-          setValueIndex(getPreviousIndex(valueIndex, values.length - 1));
+          return setValueIndex(getPreviousIndex(valueIndex, values.length - 1));
         }
         if (e.key === 'Escape') {
           e.preventDefault();
-          setTargetRange(null);
+          return setTargetRange(null);
         }
 
         if (['Tab', 'Enter'].includes(e.key)) {
           e.preventDefault();
           Transforms.select(editor, targetRange);
           insertMention(editor, values[valueIndex]);
-          setTargetRange(null);
+          return setTargetRange(null);
         }
       }
     },

--- a/packages/slate-plugins/src/elements/mention/useMention.tsx
+++ b/packages/slate-plugins/src/elements/mention/useMention.tsx
@@ -1,121 +1,81 @@
-import React, { useCallback, useState } from 'react';
-import { escapeRegExp } from 'common/utils';
+import { useCallback, useState } from 'react';
+import { isPointAtWordEnd, isWordAfterTrigger } from 'common/queries';
+import { getNextIndex } from 'elements/mention/utils/getNextIndex';
+import { getPreviousIndex } from 'elements/mention/utils/getPreviousIndex';
 import { Editor, Range, Transforms } from 'slate';
-import { MentionSelect } from './components/MentionSelect';
 import { insertMention } from './transforms';
-import { MentionableItem, MentionOptions } from './types';
-
-const AFTER_MATCH_REGEX = /^(\s|$)/;
-
-const getMentionSelect = (
-  target: Range | null,
-  index: number,
-  mentionables: MentionableItem[]
-) => {
-  return () => {
-    if (target && mentionables.length > 0) {
-      return (
-        <MentionSelect
-          target={target}
-          index={index}
-          mentionables={mentionables}
-        />
-      );
-    }
-    return null;
-  };
-};
+import { MentionableItem, UseMentionOptions } from './types';
 
 export const useMention = (
   mentionables: MentionableItem[] = [],
-  options: Partial<MentionOptions>
+  { maxSuggestions = 10, trigger = '@' }: UseMentionOptions = {}
 ) => {
-  const { maxSuggestions = 10, trigger = '@', prefix = trigger } = options;
-  const [target, setTarget] = useState<Range | null>(null);
-  const [index, setIndex] = useState(0);
+  const [targetRange, setTargetRange] = useState<Range | null>(null);
+  const [valueIndex, setValueIndex] = useState(0);
   const [search, setSearch] = useState('');
-  const matchingMentionables = mentionables
+  const values = mentionables
     .filter((c) => c.value.toLowerCase().includes(search.toLowerCase()))
     .slice(0, maxSuggestions);
 
-  const MentionSelectComponent = getMentionSelect(
-    target,
-    index,
-    matchingMentionables
-  );
-
   const onKeyDownMention = useCallback(
     (e: any, editor: Editor) => {
-      if (target) {
-        switch (e.key) {
-          case 'ArrowDown': {
-            e.preventDefault();
-            const prevIndex =
-              index >= matchingMentionables.length - 1 ? 0 : index + 1;
-            setIndex(prevIndex);
-            break;
-          }
-          case 'ArrowUp': {
-            e.preventDefault();
-            const nextIndex =
-              index <= 0 ? matchingMentionables.length - 1 : index - 1;
-            setIndex(nextIndex);
-            break;
-          }
-          case 'Tab':
-          case 'Enter':
-            e.preventDefault();
-            Transforms.select(editor, target);
-            insertMention(editor, matchingMentionables[index], prefix);
-            setTarget(null);
-            break;
-          case 'Escape':
-            e.preventDefault();
-            setTarget(null);
-            break;
-          default:
-            break;
+      if (targetRange) {
+        if (e.key === 'ArrowDown') {
+          e.preventDefault();
+          setValueIndex(getNextIndex(valueIndex, values.length - 1));
+        }
+        if (e.key === 'ArrowUp') {
+          e.preventDefault();
+          setValueIndex(getPreviousIndex(valueIndex, values.length - 1));
+        }
+        if (e.key === 'Escape') {
+          e.preventDefault();
+          setTargetRange(null);
+        }
+
+        if (['Tab', 'Enter'].includes(e.key)) {
+          e.preventDefault();
+          Transforms.select(editor, targetRange);
+          insertMention(editor, values[valueIndex]);
+          setTargetRange(null);
         }
       }
     },
-    [matchingMentionables, index, setIndex, target, setTarget, prefix]
+    [values, valueIndex, setValueIndex, targetRange, setTargetRange]
   );
 
   const onChangeMention = useCallback(
-    ({ editor }: { editor: Editor }) => {
+    (editor: Editor) => {
       const { selection } = editor;
-      const escapedTrigger = escapeRegExp(trigger);
-      const beforeRegex = new RegExp(`^${escapedTrigger}(\\w+)$`);
+
       if (selection && Range.isCollapsed(selection)) {
-        const [start] = Range.edges(selection);
-        const wordBefore = Editor.before(editor, start, { unit: 'word' });
-        const before = wordBefore && Editor.before(editor, wordBefore);
-        const beforeRange = before && Editor.range(editor, before, start);
-        const beforeText = beforeRange && Editor.string(editor, beforeRange);
-        const beforeMatch = beforeText && beforeText.match(beforeRegex);
-        const after = Editor.after(editor, start);
-        const afterRange = Editor.range(editor, start, after);
-        const afterText = Editor.string(editor, afterRange);
-        const afterMatch = afterText.match(AFTER_MATCH_REGEX);
-        if (beforeMatch && afterMatch) {
-          setTarget(beforeRange ?? null);
-          setSearch(beforeMatch[1]);
-          setIndex(0);
+        const cursor = Range.start(selection);
+
+        const { range, match: beforeMatch } = isWordAfterTrigger(editor, {
+          at: cursor,
+          trigger,
+        });
+
+        if (beforeMatch && isPointAtWordEnd(editor, { at: cursor })) {
+          setTargetRange(range as Range);
+          const [, word] = beforeMatch;
+          setSearch(word);
+          setValueIndex(0);
           return;
         }
       }
 
-      setTarget(null);
+      setTargetRange(null);
     },
-    [setTarget, setSearch, setIndex, trigger]
+    [setTargetRange, setSearch, setValueIndex, trigger]
   );
 
   return {
-    MentionSelectComponent,
+    search,
+    index: valueIndex,
+    target: targetRange,
+    values,
     onChangeMention,
     onKeyDownMention,
-    search,
-    index,
-    target,
   };
 };

--- a/packages/slate-plugins/src/elements/mention/utils/getNextIndex.ts
+++ b/packages/slate-plugins/src/elements/mention/utils/getNextIndex.ts
@@ -1,0 +1,5 @@
+/**
+ * Get next index from 0 to max.
+ * If index is max, get to 0.
+ */
+export const getNextIndex = (i: number, max: number) => (i >= max ? 0 : i + 1);

--- a/packages/slate-plugins/src/elements/mention/utils/getPreviousIndex.ts
+++ b/packages/slate-plugins/src/elements/mention/utils/getPreviousIndex.ts
@@ -1,0 +1,6 @@
+/**
+ * Get previous index from 0 to max.
+ * If index is 0, get to max.
+ */
+export const getPreviousIndex = (i: number, max: number) =>
+  i <= 0 ? max : i - 1;

--- a/packages/slate-plugins/src/elements/mention/utils/index.ts
+++ b/packages/slate-plugins/src/elements/mention/utils/index.ts
@@ -1,0 +1,2 @@
+export * from './getNextIndex';
+export * from './getPreviousIndex';

--- a/packages/slate-plugins/src/elements/mention/withMention.ts
+++ b/packages/slate-plugins/src/elements/mention/withMention.ts
@@ -1,12 +1,10 @@
 import { withInline, withVoid } from 'element';
 import { Editor } from 'slate';
-import { MENTION } from './types';
+import { MENTION, WithMentionOptions } from './types';
 
-export const withMention = ({ typeMention = MENTION } = {}) => <
-  T extends Editor
->(
-  editor: T
-) => {
+export const withMention = ({
+  typeMention = MENTION,
+}: WithMentionOptions = {}) => <T extends Editor>(editor: T) => {
   editor = withVoid([typeMention])(editor);
   editor = withInline([typeMention])(editor);
 

--- a/packages/slate-plugins/src/elements/paragraph/ParagraphPlugin.ts
+++ b/packages/slate-plugins/src/elements/paragraph/ParagraphPlugin.ts
@@ -1,10 +1,10 @@
 import { SlatePlugin } from 'common/types';
-import { RenderElementOptions } from 'element/types';
 import { renderElementParagraph } from 'elements/paragraph/renderElementParagraph';
+import { ParagraphPluginOptions } from 'elements/paragraph/types';
 import { deserializeParagraph } from './deserializeParagraph';
 
 export const ParagraphPlugin = (
-  options?: RenderElementOptions & { typeP?: string }
+  options?: ParagraphPluginOptions
 ): SlatePlugin => ({
   renderElement: renderElementParagraph(options),
   deserialize: deserializeParagraph(options),

--- a/packages/slate-plugins/src/elements/paragraph/deserializeParagraph.ts
+++ b/packages/slate-plugins/src/elements/paragraph/deserializeParagraph.ts
@@ -1,9 +1,9 @@
 import { DeserializeHtml } from 'common/types';
 import { getElementDeserializer } from 'element/utils';
-import { PARAGRAPH } from './types';
+import { PARAGRAPH, ParagraphDeserializeOptions } from './types';
 
 export const deserializeParagraph = ({
   typeP = PARAGRAPH,
-} = {}): DeserializeHtml => ({
+}: ParagraphDeserializeOptions = {}): DeserializeHtml => ({
   element: getElementDeserializer(typeP, { tagNames: ['P'] }),
 });

--- a/packages/slate-plugins/src/elements/paragraph/renderElementParagraph.ts
+++ b/packages/slate-plugins/src/elements/paragraph/renderElementParagraph.ts
@@ -1,14 +1,10 @@
-import {
-  getElementComponent,
-  getRenderElement,
-  RenderElementOptions,
-} from 'element';
-import { PARAGRAPH } from './types';
+import { getElementComponent, getRenderElement } from 'element';
+import { PARAGRAPH, ParagraphRenderElementOptions } from './types';
 
 export const renderElementParagraph = ({
   typeP = PARAGRAPH,
   component = getElementComponent('div'),
-}: RenderElementOptions = {}) =>
+}: ParagraphRenderElementOptions = {}) =>
   getRenderElement({
     type: typeP,
     component,

--- a/packages/slate-plugins/src/elements/paragraph/types.ts
+++ b/packages/slate-plugins/src/elements/paragraph/types.ts
@@ -4,11 +4,10 @@ import { RenderElementProps } from 'slate-react';
 
 export const PARAGRAPH = 'p';
 
-export interface ParagraphNodeData {
-  [key: string]: unknown;
-}
+// Data of Element node
+export interface ParagraphNodeData {}
 
-// Node
+// Element node
 export interface ParagraphNode extends Element, ParagraphNodeData {}
 
 // Option type

--- a/packages/slate-plugins/src/elements/paragraph/types.ts
+++ b/packages/slate-plugins/src/elements/paragraph/types.ts
@@ -1,1 +1,41 @@
+import { RenderElementOptions } from 'element';
+import { Element } from 'slate';
+import { RenderElementProps } from 'slate-react';
+
 export const PARAGRAPH = 'p';
+
+export interface ParagraphNodeData {
+  [key: string]: unknown;
+}
+
+// Node
+export interface ParagraphNode extends Element, ParagraphNodeData {}
+
+// Option type
+interface TypeOption {
+  typeP?: string;
+}
+
+// deserialize options
+export interface ParagraphDeserializeOptions extends TypeOption {}
+
+// renderElement options given as props
+interface ParagraphRenderElementOptionsProps {}
+
+// renderElement options
+export interface ParagraphRenderElementOptions
+  extends RenderElementOptions,
+    ParagraphRenderElementOptionsProps,
+    TypeOption {}
+
+// renderElement props
+export interface ParagraphRenderElementProps
+  extends RenderElementProps,
+    ParagraphRenderElementOptionsProps {
+  element: ParagraphNode;
+}
+
+// Plugin options
+export interface ParagraphPluginOptions
+  extends ParagraphRenderElementOptions,
+    ParagraphDeserializeOptions {}

--- a/packages/slate-plugins/src/elements/table/TablePlugin.ts
+++ b/packages/slate-plugins/src/elements/table/TablePlugin.ts
@@ -1,11 +1,9 @@
 import { SlatePlugin } from 'common/types';
 import { deserializeTable } from './deserializeTable';
 import { renderElementTable } from './renderElementTable';
-import { RenderElementTableOptions } from './types';
+import { TablePluginOptions } from './types';
 
-export const TablePlugin = (
-  options?: RenderElementTableOptions
-): SlatePlugin => ({
+export const TablePlugin = (options?: TablePluginOptions): SlatePlugin => ({
   renderElement: renderElementTable(options),
   deserialize: deserializeTable(options),
 });

--- a/packages/slate-plugins/src/elements/table/components/TableElement.tsx
+++ b/packages/slate-plugins/src/elements/table/components/TableElement.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { RenderElementProps } from 'slate-react';
+import { TableRenderElementProps } from 'elements/table/types';
 import styled from 'styled-components';
 
 export const StyledTable = styled.table`
@@ -8,7 +8,10 @@ export const StyledTable = styled.table`
   width: 100%;
 `;
 
-export const TableElement = ({ attributes, children }: RenderElementProps) => (
+export const TableElement = ({
+  attributes,
+  children,
+}: TableRenderElementProps) => (
   <StyledTable {...attributes}>
     <tbody>{children}</tbody>
   </StyledTable>

--- a/packages/slate-plugins/src/elements/table/components/ToolbarTable.tsx
+++ b/packages/slate-plugins/src/elements/table/components/ToolbarTable.tsx
@@ -1,15 +1,13 @@
 import React from 'react';
 import { isNodeInSelection } from 'common/queries';
 import { getPreventDefaultHandler } from 'common/utils/getPreventDefaultHandler';
-import { TableType, TableTypeOptions } from 'elements/table/types';
+import { TableType, TableTypeOption } from 'elements/table/types';
 import { Editor } from 'slate';
 import { useSlate } from 'slate-react';
 import { ToolbarButton, ToolbarButtonProps } from 'components/Toolbar';
 
-export interface ToolbarTableProps
-  extends ToolbarButtonProps,
-    TableTypeOptions {
-  action: (editor: Editor, options?: Required<TableTypeOptions>) => void;
+export interface ToolbarTableProps extends ToolbarButtonProps, TableTypeOption {
+  action: (editor: Editor, options?: Required<TableTypeOption>) => void;
 }
 
 export const ToolbarTable = ({

--- a/packages/slate-plugins/src/elements/table/deserializeTable.ts
+++ b/packages/slate-plugins/src/elements/table/deserializeTable.ts
@@ -1,12 +1,12 @@
 import { DeserializeHtml } from 'common/types';
 import { getElementDeserializer } from 'element/utils';
-import { TableType, TableTypeOptions } from './types';
+import { TableDeserializeOptions, TableType } from './types';
 
 export const deserializeTable = ({
   typeTable = TableType.TABLE,
   typeTr = TableType.ROW,
   typeTd = TableType.CELL,
-}: TableTypeOptions = {}): DeserializeHtml => ({
+}: TableDeserializeOptions = {}): DeserializeHtml => ({
   element: {
     ...getElementDeserializer(typeTable, { tagNames: ['TABLE'] }),
     ...getElementDeserializer(typeTr, { tagNames: ['TR'] }),

--- a/packages/slate-plugins/src/elements/table/index.ts
+++ b/packages/slate-plugins/src/elements/table/index.ts
@@ -6,3 +6,5 @@ export * from './TablePlugin';
 export * from './types';
 export * from './transforms';
 export * from './withTable';
+export * from './utils';
+export { getEmptyTableNode } from 'elements/table/utils/getEmptyTableNode';

--- a/packages/slate-plugins/src/elements/table/index.ts
+++ b/packages/slate-plugins/src/elements/table/index.ts
@@ -7,4 +7,3 @@ export * from './types';
 export * from './transforms';
 export * from './withTable';
 export * from './utils';
-export { getEmptyTableNode } from 'elements/table/utils/getEmptyTableNode';

--- a/packages/slate-plugins/src/elements/table/renderElementTable.tsx
+++ b/packages/slate-plugins/src/elements/table/renderElementTable.tsx
@@ -1,7 +1,7 @@
 import { getElementComponent, getRenderElements } from 'element/utils';
 import { TableCell } from 'elements/table/components/TableCell';
 import { TableElement } from 'elements/table/components/TableElement';
-import { RenderElementTableOptions, TableType } from './types';
+import { TableRenderElementOptions, TableType } from './types';
 
 export const renderElementTable = ({
   Table = TableElement,
@@ -10,7 +10,7 @@ export const renderElementTable = ({
   typeTable = TableType.TABLE,
   typeTr = TableType.ROW,
   typeTd = TableType.CELL,
-}: RenderElementTableOptions = {}) =>
+}: TableRenderElementOptions = {}) =>
   getRenderElements([
     { component: Table, type: typeTable },
     { component: Row, type: typeTr },

--- a/packages/slate-plugins/src/elements/table/transforms/addColumn.ts
+++ b/packages/slate-plugins/src/elements/table/transforms/addColumn.ts
@@ -1,7 +1,8 @@
 import { isNodeInSelection } from 'common/queries';
+import { getEmptyCellNode } from 'elements/table/utils/getEmptyCellNode';
 import { Editor, Path, Transforms } from 'slate';
 import { isTable, isTableCell } from '../queries';
-import { defaultTableTypes, emptyCell } from '../types';
+import { defaultTableTypes } from '../types';
 
 export const addColumn = (editor: Editor, options = defaultTableTypes) => {
   if (isNodeInSelection(editor, options.typeTable)) {
@@ -20,7 +21,7 @@ export const addColumn = (editor: Editor, options = defaultTableTypes) => {
       currentTableItem[0].children.forEach((row, rowIdx) => {
         newCellPath[replacePathPos] = rowIdx;
 
-        Transforms.insertNodes(editor, emptyCell(options), {
+        Transforms.insertNodes(editor, getEmptyCellNode(options), {
           at: newCellPath,
           select: rowIdx === currentRowIdx,
         });

--- a/packages/slate-plugins/src/elements/table/transforms/addRow.ts
+++ b/packages/slate-plugins/src/elements/table/transforms/addRow.ts
@@ -1,7 +1,8 @@
 import { isNodeInSelection } from 'common/queries';
+import { getEmptyRowNode } from 'elements/table/utils/getEmptyRowNode';
 import { Editor, Path, Transforms } from 'slate';
 import { isTableRow } from '../queries';
-import { defaultTableTypes, emptyRow } from '../types';
+import { defaultTableTypes } from '../types';
 
 export const addRow = (editor: Editor, options = defaultTableTypes) => {
   if (isNodeInSelection(editor, options.typeTable)) {
@@ -12,7 +13,7 @@ export const addRow = (editor: Editor, options = defaultTableTypes) => {
       const [currentRowElem, currentRowPath] = currentRowItem;
       Transforms.insertNodes(
         editor,
-        emptyRow(currentRowElem.children.length, options),
+        getEmptyRowNode(currentRowElem.children.length, options),
         {
           at: Path.next(currentRowPath),
           select: true,

--- a/packages/slate-plugins/src/elements/table/transforms/insertTable.ts
+++ b/packages/slate-plugins/src/elements/table/transforms/insertTable.ts
@@ -1,9 +1,10 @@
 import { isNodeInSelection } from 'common/queries';
+import { getEmptyTableNode } from 'elements/table/utils/getEmptyTableNode';
 import { Editor, Transforms } from 'slate';
-import { defaultTableTypes, emptyTable } from '../types';
+import { defaultTableTypes } from '../types';
 
 export const insertTable = (editor: Editor, options = defaultTableTypes) => {
   if (!isNodeInSelection(editor, options.typeTable)) {
-    Transforms.insertNodes(editor, emptyTable(options));
+    Transforms.insertNodes(editor, getEmptyTableNode(options));
   }
 };

--- a/packages/slate-plugins/src/elements/table/types.ts
+++ b/packages/slate-plugins/src/elements/table/types.ts
@@ -13,11 +13,10 @@ export const defaultTableTypes: Required<TableTypeOption> = {
   typeTd: TableType.CELL,
 };
 
-export interface TableNodeData {
-  [key: string]: unknown;
-}
+// Data of Element node
+export interface TableNodeData {}
 
-// Node
+// Element node
 export interface TableNode extends Element, TableNodeData {}
 
 // Option type

--- a/packages/slate-plugins/src/elements/table/types.ts
+++ b/packages/slate-plugins/src/elements/table/types.ts
@@ -1,40 +1,57 @@
+import { Element } from 'slate';
+import { RenderElementProps } from 'slate-react';
+
 export enum TableType {
   TABLE = 'table',
   ROW = 'tr',
   CELL = 'td',
 }
 
-export interface TableTypeOptions {
-  typeTable?: string;
-  typeTr?: string;
-  typeTd?: string;
-}
-
-export interface RenderElementTableOptions extends TableTypeOptions {
-  Table?: any;
-  Row?: any;
-  Cell?: any;
-}
-
-export const defaultTableTypes: Required<TableTypeOptions> = {
+export const defaultTableTypes: Required<TableTypeOption> = {
   typeTable: TableType.TABLE,
   typeTr: TableType.ROW,
   typeTd: TableType.CELL,
 };
 
-export const emptyCell = (options = defaultTableTypes) => ({
-  type: options.typeTd,
-  children: [{ text: '' }],
-});
+export interface TableNodeData {
+  [key: string]: unknown;
+}
 
-export const emptyRow = (colCount: number, options = defaultTableTypes) => ({
-  type: options.typeTr,
-  children: Array(colCount)
-    .fill(colCount)
-    .map(() => emptyCell(options)),
-});
+// Node
+export interface TableNode extends Element, TableNodeData {}
 
-export const emptyTable = (options = defaultTableTypes) => ({
-  type: options.typeTable,
-  children: [emptyRow(2, options), emptyRow(2, options)],
-});
+// Option type
+export interface TableTypeOption {
+  typeTable?: string;
+  typeTr?: string;
+  typeTd?: string;
+}
+
+// deserialize options
+export interface TableDeserializeOptions extends TableTypeOption {}
+
+// renderElement options given as props
+interface TableRenderElementOptionsProps {}
+
+// renderElement options
+export interface TableRenderElementOptions
+  extends TableRenderElementOptionsProps,
+    TableTypeOption {
+  Table?: any;
+  Row?: any;
+  Cell?: any;
+}
+
+// renderElement props
+export interface TableRenderElementProps
+  extends RenderElementProps,
+    TableRenderElementOptionsProps {
+  element: TableNode;
+}
+
+// Plugin options
+export interface TablePluginOptions
+  extends TableRenderElementOptions,
+    TableDeserializeOptions {}
+
+export interface WithTableOptions extends TableTypeOption {}

--- a/packages/slate-plugins/src/elements/table/utils/getEmptyCellNode.ts
+++ b/packages/slate-plugins/src/elements/table/utils/getEmptyCellNode.ts
@@ -1,0 +1,6 @@
+import { defaultTableTypes } from 'elements/table/types';
+
+export const getEmptyCellNode = (options = defaultTableTypes) => ({
+  type: options.typeTd,
+  children: [{ text: '' }],
+});

--- a/packages/slate-plugins/src/elements/table/utils/getEmptyRowNode.ts
+++ b/packages/slate-plugins/src/elements/table/utils/getEmptyRowNode.ts
@@ -1,0 +1,12 @@
+import { defaultTableTypes } from 'elements/table/types';
+import { getEmptyCellNode } from 'elements/table/utils/getEmptyCellNode';
+
+export const getEmptyRowNode = (
+  colCount: number,
+  options = defaultTableTypes
+) => ({
+  type: options.typeTr,
+  children: Array(colCount)
+    .fill(colCount)
+    .map(() => getEmptyCellNode(options)),
+});

--- a/packages/slate-plugins/src/elements/table/utils/getEmptyTableNode.ts
+++ b/packages/slate-plugins/src/elements/table/utils/getEmptyTableNode.ts
@@ -1,0 +1,7 @@
+import { defaultTableTypes } from 'elements/table/types';
+import { getEmptyRowNode } from 'elements/table/utils/getEmptyRowNode';
+
+export const getEmptyTableNode = (options = defaultTableTypes) => ({
+  type: options.typeTable,
+  children: [getEmptyRowNode(2, options), getEmptyRowNode(2, options)],
+});

--- a/packages/slate-plugins/src/elements/table/utils/index.ts
+++ b/packages/slate-plugins/src/elements/table/utils/index.ts
@@ -1,0 +1,3 @@
+export * from './getEmptyCellNode';
+export * from './getEmptyRowNode';
+export * from './getEmptyTableNode';

--- a/packages/slate-plugins/src/elements/table/withTable.ts
+++ b/packages/slate-plugins/src/elements/table/withTable.ts
@@ -1,10 +1,10 @@
 import { Editor, Point, Range } from 'slate';
-import { TableType } from './types';
+import { TableType, WithTableOptions } from './types';
 
 export const withTable = ({
   typeTable = TableType.TABLE,
   typeTd = TableType.CELL,
-} = {}) => <T extends Editor>(editor: T) => {
+}: WithTableOptions = {}) => <T extends Editor>(editor: T) => {
   const { deleteBackward, deleteForward, insertBreak } = editor;
 
   const preventDeleteCell = (operation: any, pointCallback: any) => (

--- a/packages/slate-plugins/src/elements/video/VideoPlugin.ts
+++ b/packages/slate-plugins/src/elements/video/VideoPlugin.ts
@@ -1,11 +1,9 @@
 import { SlatePlugin } from 'common/types';
-import { RenderElementOptions } from 'element';
 import { deserializeIframe } from 'elements/video/deserializeIframe';
+import { VideoPluginOptions } from 'elements/video/types';
 import { renderElementVideo } from './renderElementVideo';
 
-export const VideoPlugin = (
-  options?: RenderElementOptions & { typeVideo: string }
-): SlatePlugin => ({
+export const VideoPlugin = (options?: VideoPluginOptions): SlatePlugin => ({
   renderElement: renderElementVideo(options),
   deserialize: deserializeIframe(options),
 });

--- a/packages/slate-plugins/src/elements/video/components/VideoElement.tsx
+++ b/packages/slate-plugins/src/elements/video/components/VideoElement.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
+import { VideoRenderElementProps } from 'elements/video/types';
 import { Transforms } from 'slate';
-import { ReactEditor, RenderElementProps, useEditor } from 'slate-react';
+import { ReactEditor, useEditor } from 'slate-react';
 import styled from 'styled-components';
 
 const VideoWrapper = styled.div`
@@ -53,9 +54,9 @@ export const VideoElement = ({
   attributes,
   children,
   element,
-}: RenderElementProps) => {
+}: VideoRenderElementProps) => {
   const editor = useEditor();
-  const url = element.url as string;
+  const { url } = element;
 
   return (
     <div {...attributes}>

--- a/packages/slate-plugins/src/elements/video/deserializeIframe.ts
+++ b/packages/slate-plugins/src/elements/video/deserializeIframe.ts
@@ -1,9 +1,9 @@
 import { DeserializeHtml } from 'common/types';
-import { VIDEO } from './types';
+import { VIDEO, VideoDeserializeOptions } from './types';
 
 export const deserializeIframe = ({
   typeVideo = VIDEO,
-} = {}): DeserializeHtml => {
+}: VideoDeserializeOptions = {}): DeserializeHtml => {
   const createElement = (el: HTMLElement) => {
     let url = el.getAttribute('src');
     if (url) {

--- a/packages/slate-plugins/src/elements/video/renderElementVideo.ts
+++ b/packages/slate-plugins/src/elements/video/renderElementVideo.ts
@@ -1,11 +1,11 @@
-import { getRenderElement, RenderElementOptions } from 'element';
+import { getRenderElement } from 'element';
 import { VideoElement } from './components';
-import { VIDEO } from './types';
+import { VIDEO, VideoRenderElementOptions } from './types';
 
 export const renderElementVideo = ({
   typeVideo = VIDEO,
   component = VideoElement,
-}: RenderElementOptions = {}) =>
+}: VideoRenderElementOptions = {}) =>
   getRenderElement({
     type: typeVideo,
     component,

--- a/packages/slate-plugins/src/elements/video/types.ts
+++ b/packages/slate-plugins/src/elements/video/types.ts
@@ -4,12 +4,12 @@ import { RenderElementProps } from 'slate-react';
 
 export const VIDEO = 'video';
 
+// Data of Element node
 export interface VideoNodeData {
   url: string;
-  [key: string]: unknown;
 }
 
-// Node
+// Element node
 export interface VideoNode extends Element, VideoNodeData {}
 
 // Option type

--- a/packages/slate-plugins/src/elements/video/types.ts
+++ b/packages/slate-plugins/src/elements/video/types.ts
@@ -1,1 +1,42 @@
+import { RenderElementOptions } from 'element';
+import { Element } from 'slate';
+import { RenderElementProps } from 'slate-react';
+
 export const VIDEO = 'video';
+
+export interface VideoNodeData {
+  url: string;
+  [key: string]: unknown;
+}
+
+// Node
+export interface VideoNode extends Element, VideoNodeData {}
+
+// Option type
+interface TypeOption {
+  typeVideo?: string;
+}
+
+// deserialize options
+export interface VideoDeserializeOptions extends TypeOption {}
+
+// renderElement options given as props
+interface VideoRenderElementOptionsProps {}
+
+// renderElement options
+export interface VideoRenderElementOptions
+  extends RenderElementOptions,
+    VideoRenderElementOptionsProps,
+    TypeOption {}
+
+// renderElement props
+export interface VideoRenderElementProps
+  extends RenderElementProps,
+    VideoRenderElementOptionsProps {
+  element: VideoNode;
+}
+
+// Plugin options
+export interface VideoPluginOptions
+  extends VideoRenderElementOptions,
+    VideoDeserializeOptions {}

--- a/packages/slate-plugins/src/mark/onKeyDownMark.ts
+++ b/packages/slate-plugins/src/mark/onKeyDownMark.ts
@@ -1,15 +1,29 @@
 import isHotkey from 'is-hotkey';
 import { Editor } from 'slate';
 import { toggleMark } from './transforms';
-import { OnKeyDownMarkOptions } from './types';
+import { MarkOnKeyDownOptions } from './types';
 
-export const onKeyDownMark = ({
-  clear,
-  type,
-  hotkey,
-}: OnKeyDownMarkOptions) => (e: any, editor: Editor) => {
-  if (isHotkey(hotkey, e)) {
-    e.preventDefault();
-    toggleMark(editor, type, clear);
-  }
-};
+export function onKeyDownMark(
+  type: string,
+  hotkey: undefined,
+  options?: MarkOnKeyDownOptions
+): null;
+export function onKeyDownMark(
+  type: string,
+  hotkey?: string,
+  options?: MarkOnKeyDownOptions
+): (e: any, editor: Editor) => void;
+export function onKeyDownMark(
+  type: string,
+  hotkey?: string,
+  { clear }: MarkOnKeyDownOptions = {}
+) {
+  if (!hotkey) return null;
+
+  return (e: any, editor: Editor) => {
+    if (isHotkey(hotkey, e)) {
+      e.preventDefault();
+      toggleMark(editor, type, clear);
+    }
+  };
+}

--- a/packages/slate-plugins/src/mark/types.ts
+++ b/packages/slate-plugins/src/mark/types.ts
@@ -2,8 +2,10 @@ export interface MarkPluginOptions {
   hotkey?: string;
 }
 
-export interface OnKeyDownMarkOptions {
-  type: string;
+export interface MarkOnKeyDownOptions {
   clear?: string;
-  hotkey: string;
+}
+
+export interface RenderLeafOptions {
+  // component?: any;
 }

--- a/packages/slate-plugins/src/marks/bold/BoldPlugin.ts
+++ b/packages/slate-plugins/src/marks/bold/BoldPlugin.ts
@@ -4,11 +4,11 @@ import { deserializeBold } from './deserializeBold';
 import { renderLeafBold } from './renderLeafBold';
 import { BoldPluginOptions, MARK_BOLD } from './types';
 
-export const BoldPlugin = ({
-  typeBold = MARK_BOLD,
-  hotkey = 'mod+b',
-}: BoldPluginOptions = {}): SlatePlugin => ({
-  renderLeaf: renderLeafBold({ typeBold }),
-  onKeyDown: onKeyDownMark({ type: typeBold, hotkey }),
-  deserialize: deserializeBold({ typeBold }),
+export const BoldPlugin = (options: BoldPluginOptions = {}): SlatePlugin => ({
+  renderLeaf: renderLeafBold(options),
+  onKeyDown: onKeyDownMark(
+    options.typeBold ?? MARK_BOLD,
+    options.hotkey ?? 'mod+b'
+  ),
+  deserialize: deserializeBold(options),
 });

--- a/packages/slate-plugins/src/marks/bold/deserializeBold.ts
+++ b/packages/slate-plugins/src/marks/bold/deserializeBold.ts
@@ -1,9 +1,9 @@
 import { DeserializeHtml } from 'common/types';
-import { MARK_BOLD } from './types';
+import { BoldDeserializeOptions, MARK_BOLD } from './types';
 
 export const deserializeBold = ({
   typeBold = MARK_BOLD,
-} = {}): DeserializeHtml => {
+}: BoldDeserializeOptions = {}): DeserializeHtml => {
   const leaf = { [typeBold]: true };
 
   return {

--- a/packages/slate-plugins/src/marks/bold/renderLeafBold.tsx
+++ b/packages/slate-plugins/src/marks/bold/renderLeafBold.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
-import { RenderLeafProps } from 'slate-react';
-import { MARK_BOLD } from './types';
+import { BoldRenderLeafOptions, BoldRenderLeafProps, MARK_BOLD } from './types';
 
-export const renderLeafBold = ({ typeBold = MARK_BOLD } = {}) => ({
-  children,
-  leaf,
-}: RenderLeafProps) => {
+export const renderLeafBold = ({
+  typeBold = MARK_BOLD,
+}: BoldRenderLeafOptions = {}) => ({ children, leaf }: BoldRenderLeafProps) => {
   if (leaf[typeBold]) return <strong>{children}</strong>;
 
   return children;

--- a/packages/slate-plugins/src/marks/bold/types.ts
+++ b/packages/slate-plugins/src/marks/bold/types.ts
@@ -1,7 +1,41 @@
-import { MarkPluginOptions } from 'mark';
+import { MarkPluginOptions, RenderLeafOptions } from 'mark';
+import { Text } from 'slate';
+import { RenderLeafProps } from 'slate-react';
 
 export const MARK_BOLD = 'bold';
 
-export interface BoldPluginOptions extends MarkPluginOptions {
+// Data of Text node
+export interface BoldNodeData {}
+
+// Text node
+export interface BoldNode extends Text, BoldNodeData {}
+
+// Option type
+interface TypeOption {
   typeBold?: string;
 }
+
+// renderLeaf options given as props
+interface BoldRenderLeafOptionsProps {}
+
+// renderLeaf options
+export interface BoldRenderLeafOptions
+  extends RenderLeafOptions,
+    BoldRenderLeafOptionsProps,
+    TypeOption {}
+
+// renderLeaf props
+export interface BoldRenderLeafProps
+  extends RenderLeafProps,
+    BoldRenderLeafOptionsProps {
+  leaf: BoldNode;
+}
+
+// deserialize options
+export interface BoldDeserializeOptions extends TypeOption {}
+
+// Plugin options
+export interface BoldPluginOptions
+  extends MarkPluginOptions,
+    BoldRenderLeafOptions,
+    BoldDeserializeOptions {}

--- a/packages/slate-plugins/src/marks/highlight/HighlightPlugin.ts
+++ b/packages/slate-plugins/src/marks/highlight/HighlightPlugin.ts
@@ -1,11 +1,16 @@
 import { SlatePlugin } from 'common/types';
+import { onKeyDownMark } from 'mark';
 import { deserializeHighlight } from 'marks/highlight/deserializeHighlight';
 import { renderLeafHighlight } from './renderLeafHighlight';
-import { HighlightPluginOptions } from './types';
+import { HighlightPluginOptions, MARK_HIGHLIGHT } from './types';
 
 export const HighlightPlugin = (
   options: HighlightPluginOptions = {}
 ): SlatePlugin => ({
   renderLeaf: renderLeafHighlight(options),
   deserialize: deserializeHighlight(options),
+  onKeyDown: onKeyDownMark(
+    options.typeHighlight ?? MARK_HIGHLIGHT,
+    options.hotkey
+  ),
 });

--- a/packages/slate-plugins/src/marks/highlight/deserializeHighlight.ts
+++ b/packages/slate-plugins/src/marks/highlight/deserializeHighlight.ts
@@ -1,9 +1,9 @@
 import { DeserializeHtml } from 'common/types';
 import { getLeafDeserializer } from 'mark/utils';
-import { MARK_HIGHLIGHT } from './types';
+import { HighlightDeserializeOptions, MARK_HIGHLIGHT } from './types';
 
 export const deserializeHighlight = ({
   typeHighlight = MARK_HIGHLIGHT,
-} = {}): DeserializeHtml => ({
+}: HighlightDeserializeOptions = {}): DeserializeHtml => ({
   leaf: getLeafDeserializer(typeHighlight),
 });

--- a/packages/slate-plugins/src/marks/highlight/renderLeafHighlight.tsx
+++ b/packages/slate-plugins/src/marks/highlight/renderLeafHighlight.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
-import { RenderLeafProps } from 'slate-react';
 import styled from 'styled-components';
-import { MARK_HIGHLIGHT, RenderLeafHighlightOptions } from './types';
+import {
+  HighlightRenderLeafOptions,
+  HighlightRenderLeafProps,
+  MARK_HIGHLIGHT,
+} from './types';
 
 const HighlightText = styled.span<{ bg: string }>`
   background-color: ${(props) => props.bg};
@@ -10,10 +13,10 @@ const HighlightText = styled.span<{ bg: string }>`
 export const renderLeafHighlight = ({
   typeHighlight = MARK_HIGHLIGHT,
   bg = '#ffeeba',
-}: RenderLeafHighlightOptions = {}) => ({
+}: HighlightRenderLeafOptions = {}) => ({
   children,
   leaf,
-}: RenderLeafProps) => {
+}: HighlightRenderLeafProps) => {
   if (leaf[typeHighlight])
     return (
       <HighlightText data-slate-type={typeHighlight} bg={bg}>

--- a/packages/slate-plugins/src/marks/highlight/types.ts
+++ b/packages/slate-plugins/src/marks/highlight/types.ts
@@ -1,12 +1,46 @@
+import { MarkPluginOptions, RenderLeafOptions } from 'mark';
+import { Text } from 'slate';
+import { RenderLeafProps } from 'slate-react';
+
 export const MARK_HIGHLIGHT = 'highlight';
 
-export interface RenderLeafHighlightOptions {
-  typeHighlight?: string;
+// Data of Text node
+export interface HighlightNodeData {}
 
+// Text node
+export interface HighlightNode extends Text, HighlightNodeData {}
+
+// Option type
+interface TypeOption {
+  typeHighlight?: string;
+}
+
+// renderLeaf options given as props
+interface HighlightRenderLeafOptionsProps {}
+
+// renderLeaf options
+export interface HighlightRenderLeafOptions
+  extends RenderLeafOptions,
+    HighlightRenderLeafOptionsProps,
+    TypeOption {
   /**
    * Background color of the highlighted ranges
    */
   bg?: string;
 }
 
-export interface HighlightPluginOptions extends RenderLeafHighlightOptions {}
+// renderLeaf props
+export interface HighlightRenderLeafProps
+  extends RenderLeafProps,
+    HighlightRenderLeafOptionsProps {
+  leaf: HighlightNode;
+}
+
+// deserialize options
+export interface HighlightDeserializeOptions extends TypeOption {}
+
+// Plugin options
+export interface HighlightPluginOptions
+  extends MarkPluginOptions,
+    HighlightRenderLeafOptions,
+    HighlightDeserializeOptions {}

--- a/packages/slate-plugins/src/marks/inline-code/InlineCodePlugin.ts
+++ b/packages/slate-plugins/src/marks/inline-code/InlineCodePlugin.ts
@@ -4,11 +4,13 @@ import { deserializeInlineCode } from './deserializeInlineCode';
 import { renderLeafInlineCode } from './renderLeafInlineCode';
 import { InlineCodePluginOptions, MARK_CODE } from './types';
 
-export const InlineCodePlugin = ({
-  typeInlineCode = MARK_CODE,
-  hotkey = 'mod+`',
-}: InlineCodePluginOptions = {}): SlatePlugin => ({
-  renderLeaf: renderLeafInlineCode({ typeInlineCode }),
-  onKeyDown: onKeyDownMark({ type: MARK_CODE, hotkey }),
-  deserialize: deserializeInlineCode({ typeInlineCode }),
+export const InlineCodePlugin = (
+  options: InlineCodePluginOptions = {}
+): SlatePlugin => ({
+  renderLeaf: renderLeafInlineCode(options),
+  deserialize: deserializeInlineCode(options),
+  onKeyDown: onKeyDownMark(
+    options.typeInlineCode ?? MARK_CODE,
+    options.hotkey ?? 'mod+`'
+  ),
 });

--- a/packages/slate-plugins/src/marks/inline-code/deserializeInlineCode.ts
+++ b/packages/slate-plugins/src/marks/inline-code/deserializeInlineCode.ts
@@ -1,10 +1,10 @@
 import { DeserializeHtml } from 'common/types';
 import { getLeafDeserializer } from 'mark/utils';
-import { MARK_CODE } from './types';
+import { InlineCodeDeserializeOptions, MARK_CODE } from './types';
 
 export const deserializeInlineCode = ({
   typeInlineCode = MARK_CODE,
-} = {}): DeserializeHtml => ({
+}: InlineCodeDeserializeOptions = {}): DeserializeHtml => ({
   leaf: getLeafDeserializer(typeInlineCode, {
     tagNames: ['CODE', 'KBD'],
   }),

--- a/packages/slate-plugins/src/marks/inline-code/renderLeafInlineCode.tsx
+++ b/packages/slate-plugins/src/marks/inline-code/renderLeafInlineCode.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
-import { RenderLeafProps } from 'slate-react';
 import styled from 'styled-components';
-import { MARK_CODE } from './types';
+import {
+  InlineCodeRenderLeafOptions,
+  InlineCodeRenderLeafProps,
+  MARK_CODE,
+} from './types';
 
 const Code = styled.code`
   font-family: monospace;
@@ -10,10 +13,12 @@ const Code = styled.code`
   padding: 3px;
 `;
 
-export const renderLeafInlineCode = ({ typeInlineCode = MARK_CODE } = {}) => ({
+export const renderLeafInlineCode = ({
+  typeInlineCode = MARK_CODE,
+}: InlineCodeRenderLeafOptions = {}) => ({
   children,
   leaf,
-}: RenderLeafProps) => {
+}: InlineCodeRenderLeafProps) => {
   if (leaf[typeInlineCode]) return <Code>{children}</Code>;
 
   return children;

--- a/packages/slate-plugins/src/marks/inline-code/types.ts
+++ b/packages/slate-plugins/src/marks/inline-code/types.ts
@@ -1,7 +1,41 @@
-import { MarkPluginOptions } from 'mark';
+import { MarkPluginOptions, RenderLeafOptions } from 'mark';
+import { Text } from 'slate';
+import { RenderLeafProps } from 'slate-react';
 
 export const MARK_CODE = 'code';
 
-export interface InlineCodePluginOptions extends MarkPluginOptions {
+// Data of Text node
+export interface InlineCodeNodeData {}
+
+// Text node
+export interface InlineCodeNode extends Text, InlineCodeNodeData {}
+
+// Option type
+interface TypeOption {
   typeInlineCode?: string;
 }
+
+// renderLeaf options given as props
+interface InlineCodeRenderLeafOptionsProps {}
+
+// renderLeaf options
+export interface InlineCodeRenderLeafOptions
+  extends RenderLeafOptions,
+    InlineCodeRenderLeafOptionsProps,
+    TypeOption {}
+
+// renderLeaf props
+export interface InlineCodeRenderLeafProps
+  extends RenderLeafProps,
+    InlineCodeRenderLeafOptionsProps {
+  leaf: InlineCodeNode;
+}
+
+// deserialize options
+export interface InlineCodeDeserializeOptions extends TypeOption {}
+
+// Plugin options
+export interface InlineCodePluginOptions
+  extends MarkPluginOptions,
+    InlineCodeRenderLeafOptions,
+    InlineCodeDeserializeOptions {}

--- a/packages/slate-plugins/src/marks/italic/ItalicPlugin.ts
+++ b/packages/slate-plugins/src/marks/italic/ItalicPlugin.ts
@@ -4,11 +4,13 @@ import { deserializeItalic } from './deserializeItalic';
 import { renderLeafItalic } from './renderLeafItalic';
 import { ItalicPluginOptions, MARK_ITALIC } from './types';
 
-export const ItalicPlugin = ({
-  typeItalic = MARK_ITALIC,
-  hotkey = 'mod+i',
-}: ItalicPluginOptions = {}): SlatePlugin => ({
-  renderLeaf: renderLeafItalic({ typeItalic }),
-  onKeyDown: onKeyDownMark({ type: typeItalic, hotkey }),
-  deserialize: deserializeItalic({ typeItalic }),
+export const ItalicPlugin = (
+  options: ItalicPluginOptions = {}
+): SlatePlugin => ({
+  renderLeaf: renderLeafItalic(options),
+  onKeyDown: onKeyDownMark(
+    options.typeItalic ?? MARK_ITALIC,
+    options.hotkey ?? 'mod+i'
+  ),
+  deserialize: deserializeItalic(options),
 });

--- a/packages/slate-plugins/src/marks/italic/deserializeItalic.ts
+++ b/packages/slate-plugins/src/marks/italic/deserializeItalic.ts
@@ -1,10 +1,10 @@
 import { DeserializeHtml } from 'common/types';
 import { getLeafDeserializer } from 'mark/utils';
-import { MARK_ITALIC } from './types';
+import { ItalicDeserializeOptions, MARK_ITALIC } from './types';
 
 export const deserializeItalic = ({
   typeItalic = MARK_ITALIC,
-} = {}): DeserializeHtml => ({
+}: ItalicDeserializeOptions = {}): DeserializeHtml => ({
   leaf: {
     SPAN: (el) => el.style.fontStyle === 'italic' && { [typeItalic]: true },
     ...getLeafDeserializer(typeItalic, { tagNames: ['EM', 'I'] }),

--- a/packages/slate-plugins/src/marks/italic/renderLeafItalic.tsx
+++ b/packages/slate-plugins/src/marks/italic/renderLeafItalic.tsx
@@ -1,11 +1,16 @@
 import React from 'react';
-import { RenderLeafProps } from 'slate-react';
-import { MARK_ITALIC } from './types';
+import {
+  ItalicRenderLeafOptions,
+  ItalicRenderLeafProps,
+  MARK_ITALIC,
+} from './types';
 
-export const renderLeafItalic = ({ typeItalic = MARK_ITALIC } = {}) => ({
+export const renderLeafItalic = ({
+  typeItalic = MARK_ITALIC,
+}: ItalicRenderLeafOptions = {}) => ({
   children,
   leaf,
-}: RenderLeafProps) => {
+}: ItalicRenderLeafProps) => {
   if (leaf[typeItalic]) return <em>{children}</em>;
 
   return children;

--- a/packages/slate-plugins/src/marks/italic/types.ts
+++ b/packages/slate-plugins/src/marks/italic/types.ts
@@ -1,7 +1,41 @@
-import { MarkPluginOptions } from 'mark';
+import { MarkPluginOptions, RenderLeafOptions } from 'mark';
+import { Text } from 'slate';
+import { RenderLeafProps } from 'slate-react';
 
 export const MARK_ITALIC = 'italic';
 
-export interface ItalicPluginOptions extends MarkPluginOptions {
+// Data of Text node
+export interface ItalicNodeData {}
+
+// Text node
+export interface ItalicNode extends Text, ItalicNodeData {}
+
+// Option type
+interface TypeOption {
   typeItalic?: string;
 }
+
+// renderLeaf options given as props
+interface ItalicRenderLeafOptionsProps {}
+
+// renderLeaf options
+export interface ItalicRenderLeafOptions
+  extends RenderLeafOptions,
+    ItalicRenderLeafOptionsProps,
+    TypeOption {}
+
+// renderLeaf props
+export interface ItalicRenderLeafProps
+  extends RenderLeafProps,
+    ItalicRenderLeafOptionsProps {
+  leaf: ItalicNode;
+}
+
+// deserialize options
+export interface ItalicDeserializeOptions extends TypeOption {}
+
+// Plugin options
+export interface ItalicPluginOptions
+  extends MarkPluginOptions,
+    ItalicRenderLeafOptions,
+    ItalicDeserializeOptions {}

--- a/packages/slate-plugins/src/marks/strikethrough/StrikethroughPlugin.ts
+++ b/packages/slate-plugins/src/marks/strikethrough/StrikethroughPlugin.ts
@@ -4,11 +4,13 @@ import { deserializeStrikethrough } from 'marks/strikethrough/deserializeStriket
 import { renderLeafStrikethrough } from './renderLeafStrikethrough';
 import { MARK_STRIKETHROUGH, StrikethroughPluginOptions } from './types';
 
-export const StrikethroughPlugin = ({
-  typeStrikethrough = MARK_STRIKETHROUGH,
-  hotkey = 'mod+shift+k',
-}: StrikethroughPluginOptions = {}): SlatePlugin => ({
-  renderLeaf: renderLeafStrikethrough({ typeStrikethrough }),
-  onKeyDown: onKeyDownMark({ type: typeStrikethrough, hotkey }),
-  deserialize: deserializeStrikethrough({ typeStrikethrough }),
+export const StrikethroughPlugin = (
+  options: StrikethroughPluginOptions = {}
+): SlatePlugin => ({
+  renderLeaf: renderLeafStrikethrough(options),
+  onKeyDown: onKeyDownMark(
+    options.typeStrikethrough ?? MARK_STRIKETHROUGH,
+    options.hotkey ?? 'mod+shift+k'
+  ),
+  deserialize: deserializeStrikethrough(options),
 });

--- a/packages/slate-plugins/src/marks/strikethrough/deserializeStrikethrough.ts
+++ b/packages/slate-plugins/src/marks/strikethrough/deserializeStrikethrough.ts
@@ -1,10 +1,10 @@
 import { DeserializeHtml } from 'common/types';
 import { getLeafDeserializer } from 'mark/utils';
-import { MARK_STRIKETHROUGH } from './types';
+import { MARK_STRIKETHROUGH, StrikethroughDeserializeOptions } from './types';
 
 export const deserializeStrikethrough = ({
   typeStrikethrough = MARK_STRIKETHROUGH,
-} = {}): DeserializeHtml => ({
+}: StrikethroughDeserializeOptions = {}): DeserializeHtml => ({
   leaf: {
     ...getLeafDeserializer(typeStrikethrough, { tagNames: ['DEL', 'S'] }),
     SPAN: (el) =>

--- a/packages/slate-plugins/src/marks/strikethrough/renderLeafStrikethrough.tsx
+++ b/packages/slate-plugins/src/marks/strikethrough/renderLeafStrikethrough.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
-import { RenderLeafProps } from 'slate-react';
 import styled from 'styled-components';
-import { MARK_STRIKETHROUGH } from './types';
+import {
+  MARK_STRIKETHROUGH,
+  StrikethroughRenderLeafOptions,
+  StrikethroughRenderLeafProps,
+} from './types';
 
 const StrikethroughText = styled.span`
   text-decoration: line-through;
@@ -9,7 +12,10 @@ const StrikethroughText = styled.span`
 
 export const renderLeafStrikethrough = ({
   typeStrikethrough = MARK_STRIKETHROUGH,
-} = {}) => ({ children, leaf }: RenderLeafProps) => {
+}: StrikethroughRenderLeafOptions = {}) => ({
+  children,
+  leaf,
+}: StrikethroughRenderLeafProps) => {
   if (leaf[typeStrikethrough]) {
     return (
       <StrikethroughText data-slate-type={typeStrikethrough}>

--- a/packages/slate-plugins/src/marks/strikethrough/types.ts
+++ b/packages/slate-plugins/src/marks/strikethrough/types.ts
@@ -1,7 +1,41 @@
-import { MarkPluginOptions } from 'mark';
+import { MarkPluginOptions, RenderLeafOptions } from 'mark';
+import { Text } from 'slate';
+import { RenderLeafProps } from 'slate-react';
 
 export const MARK_STRIKETHROUGH = 'strikethrough';
 
-export interface StrikethroughPluginOptions extends MarkPluginOptions {
+// Data of Text node
+export interface StrikethroughNodeData {}
+
+// Text node
+export interface StrikethroughNode extends Text, StrikethroughNodeData {}
+
+// Option type
+interface TypeOption {
   typeStrikethrough?: string;
 }
+
+// renderLeaf options given as props
+interface StrikethroughRenderLeafOptionsProps {}
+
+// renderLeaf options
+export interface StrikethroughRenderLeafOptions
+  extends RenderLeafOptions,
+    StrikethroughRenderLeafOptionsProps,
+    TypeOption {}
+
+// renderLeaf props
+export interface StrikethroughRenderLeafProps
+  extends RenderLeafProps,
+    StrikethroughRenderLeafOptionsProps {
+  leaf: StrikethroughNode;
+}
+
+// deserialize options
+export interface StrikethroughDeserializeOptions extends TypeOption {}
+
+// Plugin options
+export interface StrikethroughPluginOptions
+  extends MarkPluginOptions,
+    StrikethroughRenderLeafOptions,
+    StrikethroughDeserializeOptions {}

--- a/packages/slate-plugins/src/marks/subscript/SubscriptPlugin.ts
+++ b/packages/slate-plugins/src/marks/subscript/SubscriptPlugin.ts
@@ -5,16 +5,16 @@ import { deserializeSubscript } from './deserializeSubscript';
 import { renderLeafSubscript } from './renderLeafSubscript';
 import { MARK_SUBSCRIPT, SubscriptPluginOptions } from './types';
 
-export const SubscriptPlugin = ({
-  typeSuperscript = MARK_SUPERSCRIPT,
-  typeSubscript = MARK_SUBSCRIPT,
-  hotkey = 'mod+,',
-}: SubscriptPluginOptions = {}): SlatePlugin => ({
-  renderLeaf: renderLeafSubscript({ typeSubscript }),
-  onKeyDown: onKeyDownMark({
-    type: typeSubscript,
-    clear: typeSuperscript,
-    hotkey,
-  }),
-  deserialize: deserializeSubscript({ typeSubscript }),
+export const SubscriptPlugin = (
+  options: SubscriptPluginOptions = {}
+): SlatePlugin => ({
+  renderLeaf: renderLeafSubscript(options),
+  deserialize: deserializeSubscript(options),
+  onKeyDown: onKeyDownMark(
+    options.typeSubscript ?? MARK_SUBSCRIPT,
+    options.hotkey ?? 'mod+,',
+    {
+      clear: options.typeSuperscript ?? MARK_SUPERSCRIPT,
+    }
+  ),
 });

--- a/packages/slate-plugins/src/marks/subscript/deserializeSubscript.ts
+++ b/packages/slate-plugins/src/marks/subscript/deserializeSubscript.ts
@@ -1,9 +1,12 @@
 import { DeserializeHtml } from 'common/types';
 import { getLeafDeserializer } from 'mark/utils';
-import { MARK_SUBSCRIPT } from 'marks/subscript/types';
+import {
+  MARK_SUBSCRIPT,
+  SubscriptDeserializeOptions,
+} from 'marks/subscript/types';
 
 export const deserializeSubscript = ({
   typeSubscript = MARK_SUBSCRIPT,
-} = {}): DeserializeHtml => ({
+}: SubscriptDeserializeOptions = {}): DeserializeHtml => ({
   leaf: getLeafDeserializer(typeSubscript, { tagNames: ['SUB'] }),
 });

--- a/packages/slate-plugins/src/marks/subscript/renderLeafSubscript.tsx
+++ b/packages/slate-plugins/src/marks/subscript/renderLeafSubscript.tsx
@@ -1,10 +1,16 @@
 import React from 'react';
-import { RenderLeafProps } from 'slate-react';
-import { MARK_SUBSCRIPT } from './types';
+import {
+  MARK_SUBSCRIPT,
+  SubscriptRenderLeafOptions,
+  SubscriptRenderLeafProps,
+} from './types';
 
 export const renderLeafSubscript = ({
   typeSubscript = MARK_SUBSCRIPT,
-} = {}) => ({ children, leaf }: RenderLeafProps) => {
+}: SubscriptRenderLeafOptions = {}) => ({
+  children,
+  leaf,
+}: SubscriptRenderLeafProps) => {
   if (leaf[typeSubscript]) return <sub>{children}</sub>;
 
   return children;

--- a/packages/slate-plugins/src/marks/subscript/types.ts
+++ b/packages/slate-plugins/src/marks/subscript/types.ts
@@ -1,8 +1,42 @@
-import { MarkPluginOptions } from 'mark';
+import { MarkPluginOptions, RenderLeafOptions } from 'mark';
+import { Text } from 'slate';
+import { RenderLeafProps } from 'slate-react';
 
 export const MARK_SUBSCRIPT = 'SUBSCRIPT';
 
-export interface SubscriptPluginOptions extends MarkPluginOptions {
+// Data of Text node
+export interface SubscriptNodeData {}
+
+// Text node
+export interface SubscriptNode extends Text, SubscriptNodeData {}
+
+// Option type
+interface TypeOption {
   typeSubscript?: string;
   typeSuperscript?: string;
 }
+
+// renderLeaf options given as props
+interface SubscriptRenderLeafOptionsProps {}
+
+// renderLeaf options
+export interface SubscriptRenderLeafOptions
+  extends RenderLeafOptions,
+    SubscriptRenderLeafOptionsProps,
+    TypeOption {}
+
+// renderLeaf props
+export interface SubscriptRenderLeafProps
+  extends RenderLeafProps,
+    SubscriptRenderLeafOptionsProps {
+  leaf: SubscriptNode;
+}
+
+// deserialize options
+export interface SubscriptDeserializeOptions extends TypeOption {}
+
+// Plugin options
+export interface SubscriptPluginOptions
+  extends MarkPluginOptions,
+    SubscriptRenderLeafOptions,
+    SubscriptDeserializeOptions {}

--- a/packages/slate-plugins/src/marks/superscript/SuperscriptPlugin.ts
+++ b/packages/slate-plugins/src/marks/superscript/SuperscriptPlugin.ts
@@ -8,16 +8,16 @@ import {
   SuperscriptPluginOptions,
 } from 'marks/superscript/types';
 
-export const SuperscriptPlugin = ({
-  typeSuperscript = MARK_SUPERSCRIPT,
-  typeSubscript = MARK_SUBSCRIPT,
-  hotkey = 'mod+.',
-}: SuperscriptPluginOptions = {}): SlatePlugin => ({
-  renderLeaf: renderLeafSuperscript({ typeSuperscript }),
-  onKeyDown: onKeyDownMark({
-    type: typeSuperscript,
-    clear: typeSubscript,
-    hotkey,
-  }),
-  deserialize: deserializeSuperscript({ typeSuperscript }),
+export const SuperscriptPlugin = (
+  options: SuperscriptPluginOptions = {}
+): SlatePlugin => ({
+  renderLeaf: renderLeafSuperscript(options),
+  deserialize: deserializeSuperscript(options),
+  onKeyDown: onKeyDownMark(
+    options.typeSuperscript ?? MARK_SUPERSCRIPT,
+    options.hotkey ?? 'mod+.',
+    {
+      clear: options.typeSubscript ?? MARK_SUBSCRIPT,
+    }
+  ),
 });

--- a/packages/slate-plugins/src/marks/superscript/deserializeSuperscript.ts
+++ b/packages/slate-plugins/src/marks/superscript/deserializeSuperscript.ts
@@ -1,9 +1,9 @@
 import { DeserializeHtml } from 'common/types';
 import { getLeafDeserializer } from 'mark/utils';
-import { MARK_SUPERSCRIPT } from './types';
+import { MARK_SUPERSCRIPT, SuperscriptDeserializeOptions } from './types';
 
 export const deserializeSuperscript = ({
   typeSuperscript = MARK_SUPERSCRIPT,
-} = {}): DeserializeHtml => ({
+}: SuperscriptDeserializeOptions = {}): DeserializeHtml => ({
   leaf: getLeafDeserializer(typeSuperscript, { tagNames: ['SUP'] }),
 });

--- a/packages/slate-plugins/src/marks/superscript/renderLeafSuperscript.tsx
+++ b/packages/slate-plugins/src/marks/superscript/renderLeafSuperscript.tsx
@@ -1,10 +1,16 @@
 import React from 'react';
-import { RenderLeafProps } from 'slate-react';
-import { MARK_SUPERSCRIPT } from './types';
+import {
+  MARK_SUPERSCRIPT,
+  SuperscriptRenderLeafOptions,
+  SuperscriptRenderLeafProps,
+} from './types';
 
 export const renderLeafSuperscript = ({
   typeSuperscript = MARK_SUPERSCRIPT,
-} = {}) => ({ children, leaf }: RenderLeafProps) => {
+}: SuperscriptRenderLeafOptions = {}) => ({
+  children,
+  leaf,
+}: SuperscriptRenderLeafProps) => {
   if (leaf[typeSuperscript]) return <sup>{children}</sup>;
 
   return children;

--- a/packages/slate-plugins/src/marks/superscript/types.ts
+++ b/packages/slate-plugins/src/marks/superscript/types.ts
@@ -1,8 +1,42 @@
-import { MarkPluginOptions } from 'mark';
+import { MarkPluginOptions, RenderLeafOptions } from 'mark';
+import { Text } from 'slate';
+import { RenderLeafProps } from 'slate-react';
 
 export const MARK_SUPERSCRIPT = 'SUPERSCRIPT';
 
-export interface SuperscriptPluginOptions extends MarkPluginOptions {
-  typeSuperscript?: string;
+// Data of Text node
+export interface SuperscriptNodeData {}
+
+// Text node
+export interface SuperscriptNode extends Text, SuperscriptNodeData {}
+
+// Option type
+interface TypeOption {
   typeSubscript?: string;
+  typeSuperscript?: string;
 }
+
+// renderLeaf options given as props
+interface SuperscriptRenderLeafOptionsProps {}
+
+// renderLeaf options
+export interface SuperscriptRenderLeafOptions
+  extends RenderLeafOptions,
+    SuperscriptRenderLeafOptionsProps,
+    TypeOption {}
+
+// renderLeaf props
+export interface SuperscriptRenderLeafProps
+  extends RenderLeafProps,
+    SuperscriptRenderLeafOptionsProps {
+  leaf: SuperscriptNode;
+}
+
+// deserialize options
+export interface SuperscriptDeserializeOptions extends TypeOption {}
+
+// Plugin options
+export interface SuperscriptPluginOptions
+  extends MarkPluginOptions,
+    SuperscriptRenderLeafOptions,
+    SuperscriptDeserializeOptions {}

--- a/packages/slate-plugins/src/marks/underline/UnderlinePlugin.ts
+++ b/packages/slate-plugins/src/marks/underline/UnderlinePlugin.ts
@@ -4,11 +4,13 @@ import { deserializeUnderline } from 'marks/underline/deserializeUnderline';
 import { renderLeafUnderline } from './renderLeafUnderline';
 import { MARK_UNDERLINE, UnderlinePluginOptions } from './types';
 
-export const UnderlinePlugin = ({
-  typeUnderline = MARK_UNDERLINE,
-  hotkey = 'mod+u',
-}: UnderlinePluginOptions = {}): SlatePlugin => ({
-  renderLeaf: renderLeafUnderline({ typeUnderline }),
-  onKeyDown: onKeyDownMark({ type: typeUnderline, hotkey }),
-  deserialize: deserializeUnderline({ typeUnderline }),
+export const UnderlinePlugin = (
+  options: UnderlinePluginOptions = {}
+): SlatePlugin => ({
+  renderLeaf: renderLeafUnderline(options),
+  deserialize: deserializeUnderline(options),
+  onKeyDown: onKeyDownMark(
+    options.typeUnderline ?? MARK_UNDERLINE,
+    options.hotkey ?? 'mod+u'
+  ),
 });

--- a/packages/slate-plugins/src/marks/underline/deserializeUnderline.ts
+++ b/packages/slate-plugins/src/marks/underline/deserializeUnderline.ts
@@ -1,10 +1,10 @@
 import { DeserializeHtml } from 'common/types';
 import { getLeafDeserializer } from 'mark/utils';
-import { MARK_UNDERLINE } from './types';
+import { MARK_UNDERLINE, UnderlineDeserializeOptions } from './types';
 
 export const deserializeUnderline = ({
   typeUnderline = MARK_UNDERLINE,
-} = {}): DeserializeHtml => ({
+}: UnderlineDeserializeOptions = {}): DeserializeHtml => ({
   leaf: {
     SPAN: (el) =>
       el.style.textDecoration === 'underline' && { [typeUnderline]: true },

--- a/packages/slate-plugins/src/marks/underline/renderLeafUnderline.tsx
+++ b/packages/slate-plugins/src/marks/underline/renderLeafUnderline.tsx
@@ -1,10 +1,16 @@
 import React from 'react';
-import { RenderLeafProps } from 'slate-react';
-import { MARK_UNDERLINE } from './types';
+import {
+  MARK_UNDERLINE,
+  UnderlineRenderLeafOptions,
+  UnderlineRenderLeafProps,
+} from './types';
 
 export const renderLeafUnderline = ({
   typeUnderline = MARK_UNDERLINE,
-} = {}) => ({ children, leaf }: RenderLeafProps) => {
+}: UnderlineRenderLeafOptions = {}) => ({
+  children,
+  leaf,
+}: UnderlineRenderLeafProps) => {
   if (leaf[typeUnderline]) return <u>{children}</u>;
 
   return children;

--- a/packages/slate-plugins/src/marks/underline/types.ts
+++ b/packages/slate-plugins/src/marks/underline/types.ts
@@ -1,7 +1,41 @@
-import { MarkPluginOptions } from 'mark';
+import { MarkPluginOptions, RenderLeafOptions } from 'mark';
+import { Text } from 'slate';
+import { RenderLeafProps } from 'slate-react';
 
 export const MARK_UNDERLINE = 'underline';
 
-export interface UnderlinePluginOptions extends MarkPluginOptions {
+// Data of Text node
+export interface UnderlineNodeData {}
+
+// Text node
+export interface UnderlineNode extends Text, UnderlineNodeData {}
+
+// Option type
+interface TypeOption {
   typeUnderline?: string;
 }
+
+// renderLeaf options given as props
+interface UnderlineRenderLeafOptionsProps {}
+
+// renderLeaf options
+export interface UnderlineRenderLeafOptions
+  extends RenderLeafOptions,
+    UnderlineRenderLeafOptionsProps,
+    TypeOption {}
+
+// renderLeaf props
+export interface UnderlineRenderLeafProps
+  extends RenderLeafProps,
+    UnderlineRenderLeafOptionsProps {
+  leaf: UnderlineNode;
+}
+
+// deserialize options
+export interface UnderlineDeserializeOptions extends TypeOption {}
+
+// Plugin options
+export interface UnderlinePluginOptions
+  extends MarkPluginOptions,
+    UnderlineRenderLeafOptions,
+    UnderlineDeserializeOptions {}

--- a/stories/config/initialValues.ts
+++ b/stories/config/initialValues.ts
@@ -354,15 +354,13 @@ export const initialValueMentions: Node[] = [
       { text: 'Try mentioning characters, like ' },
       {
         type: nodeTypes.typeMention,
-        prefix: '@',
-        mentionable: { value: 'R2-D2' },
+        value: 'R2-D2',
         children: [{ text: '' }],
       },
       { text: ' or ' },
       {
         type: nodeTypes.typeMention,
-        prefix: '@',
-        mentionable: {value: 'Mace Windu' },
+        value: 'Mace Windu',
         children: [{ text: '' }],
       },
       { text: '!' },

--- a/stories/config/mentionables.ts
+++ b/stories/config/mentionables.ts
@@ -1,6 +1,6 @@
 import { MentionableItem } from 'slate-plugins-next/src';
 
-export const MENTIONS: MentionableItem[] = [
+export const MENTIONABLES: MentionableItem[] = [
   { value: 'Aayla Secura' },
   { value: 'Adi Gallia' },
   { value: 'Admiral Dodd Rancit' },

--- a/stories/config/mentionables.ts
+++ b/stories/config/mentionables.ts
@@ -1,6 +1,6 @@
-import { MentionableItem } from 'slate-plugins-next/src';
+import { MentionNodeData } from 'slate-plugins-next/src';
 
-export const MENTIONABLES: MentionableItem[] = [
+export const MENTIONABLES: MentionNodeData[] = [
   { value: 'Aayla Secura' },
   { value: 'Adi Gallia' },
   { value: 'Admiral Dodd Rancit' },

--- a/stories/element/inline-void/mention.stories.tsx
+++ b/stories/element/inline-void/mention.stories.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useState } from 'react';
+import { text } from '@storybook/addon-knobs';
 import { createEditor } from 'slate';
 import { withHistory } from 'slate-history';
 import { Slate, withReact } from 'slate-react';
@@ -12,7 +13,7 @@ import {
   withMention,
 } from '../../../packages/slate-plugins/src';
 import { initialValueMentions, nodeTypes } from '../../config/initialValues';
-import { MENTIONS } from '../../config/mentions';
+import { MENTIONABLES } from '../../config/mentionables';
 
 export default {
   title: 'Element/Inline Void/Mention',
@@ -23,27 +24,33 @@ export default {
   },
 };
 
-const plugins = [ParagraphPlugin(nodeTypes), MentionPlugin(nodeTypes)];
-
 const withPlugins = [withReact, withHistory, withMention(nodeTypes)] as const;
 
 export const Example = () => {
+  const plugins = [
+    ParagraphPlugin(nodeTypes),
+    MentionPlugin({
+      ...nodeTypes,
+      prefix: text('prefix', '@'),
+    }),
+  ];
+
   const createReactEditor = () => () => {
     const [value, setValue] = useState(initialValueMentions);
 
     const editor = useMemo(() => pipe(createEditor(), ...withPlugins), []);
 
     const {
-      MentionSelectComponent,
       onChangeMention,
       onKeyDownMention,
       search,
       index,
       target,
-    } = useMention(MENTIONS, {
+      values,
+    } = useMention(MENTIONABLES, {
       maxSuggestions: 10,
       trigger: '@',
-      prefix: '',
+      // prefix: text('prefix'),
     });
 
     return (
@@ -53,7 +60,7 @@ export const Example = () => {
         onChange={(newValue) => {
           setValue(newValue);
 
-          onChangeMention({ editor });
+          onChangeMention(editor);
         }}
       >
         <EditablePlugins
@@ -62,7 +69,8 @@ export const Example = () => {
           onKeyDown={[onKeyDownMention]}
           onKeyDownDeps={[index, search, target]}
         />
-        <MentionSelectComponent />
+
+        <MentionSelect at={target} valueIndex={index} options={values} />
       </Slate>
     );
   };

--- a/stories/examples/playground.stories.tsx
+++ b/stories/examples/playground.stories.tsx
@@ -48,6 +48,7 @@ import {
   MARK_SUPERSCRIPT,
   MARK_UNDERLINE,
   MentionPlugin,
+  MentionSelect,
   ParagraphPlugin,
   pipe,
   SearchHighlightPlugin,
@@ -93,7 +94,7 @@ import {
   initialValueTables,
   nodeTypes,
 } from '../config/initialValues';
-import { MENTIONS } from '../config/mentions';
+import { MENTIONABLES } from '../config/mentionables';
 import { EDITABLE_VOID } from '../element/block-void/editable-voids/types';
 
 export default {
@@ -192,13 +193,12 @@ export const Plugins = () => {
       decorate.push(decorateSearchHighlight({ search }));
 
     const {
-      MentionSelectComponent,
       index,
       search: mentionSearch,
       target,
       onChangeMention,
       onKeyDownMention,
-    } = useMention(MENTIONS, {
+    } = useMention(MENTIONABLES, {
       maxSuggestions: 10,
     });
 
@@ -211,7 +211,7 @@ export const Plugins = () => {
         onChange={(newValue) => {
           setValue(newValue);
 
-          onChangeMention({ editor });
+          onChangeMention(editor);
         }}
       >
         <ToolbarSearchHighlight icon={Search} setSearch={setSearchHighlight} />
@@ -267,7 +267,7 @@ export const Plugins = () => {
             icon={<FormatUnderlined />}
           />
         </HoveringToolbar>
-        <MentionSelectComponent />
+        <MentionSelect at={target} valueIndex={index} options={MENTIONABLES} />
         <EditablePlugins
           plugins={plugins}
           decorate={decorate}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "suppressImplicitAnyIndexErrors": true,
     "baseUrl": "packages/slate-plugins/src"
   },
-  "exclude": ["node_modules", "dist", "scripts"],
+  "exclude": ["node_modules", "dist", "scripts", "**/*template*"],
   "awesomeTypescriptLoaderOptions": {
     "ignoreDiagnostics": [7005]
   }


### PR DESCRIPTION
Testing and refactoring of the mention plugin. You can also play with the `prefix` in storybook.

###### BREAKING CHANGE

- `useMention`:
  - removed `MentionSelectComponent` from return
- `onChangeMention`:
  - signature changed from `({ editor }: { editor: Editor })` to
    `(editor: Editor)`
- `MentionSelect`:
  - props renaming:
    - from `mentionables` to `options`
    - from `index` to `valueIndex`
    - from `target` to `at`
- `MentionNode` interface: replaced `mentionable` by `value`. You can
  add more fields to the element interface instead of adding them to
  `mentionable`
- `onKeyDownMark`:
  - signature changed from `({ clear, type, hotkey, }:
    MarkOnKeyDownOptions)` to `(type: string, hotkey: string, { clear }:
    MarkOnKeyDownOptions = {})`

###### NEW

- `utils`:
  - `getPreviousIndex`
  - `getNextIndex`
- `queries`:
  - `isPointAtWordEnd`
  - `isWordAfterTrigger`
- `useMention`:
  - `options` is now optional
- `MentionPlugin`, `renderElementMention`:
  - added `prefix` option
  - added `onClick` option
- `MentionSelect`:
  - added props:
    - `styles`, see
      [Component Styling](https://github.com/microsoft/fluentui/wiki/Component-Styling)
- `getRenderElement`
  - added a 3rd argument: `options` that will be passed to the component
    as props. You should use that for static props (same value for all
    instances). And you should mutate the element when it's dynamic.
- `MentionElement`:
  - attribute `data-slate-character` renamed to `data-slate-value`
