### PR TITLE
selection works with mouse

### DIFF
--- a/packages/slate-plugins/src/__tests__/elements/mention/MentionSelect/at/null.spec.tsx
+++ b/packages/slate-plugins/src/__tests__/elements/mention/MentionSelect/at/null.spec.tsx
@@ -13,6 +13,7 @@ it('should render null', () => {
       at={null}
       options={mentionables}
       valueIndex={0}
+      onClickMention={() => {}}
     />
   );
 

--- a/packages/slate-plugins/src/__tests__/elements/mention/MentionSelect/at/range.spec.tsx
+++ b/packages/slate-plugins/src/__tests__/elements/mention/MentionSelect/at/range.spec.tsx
@@ -40,6 +40,7 @@ it('should render null', () => {
       at={editor.selection}
       options={mentionables}
       valueIndex={0}
+      onClickMention={() => {}}
     />
   );
 

--- a/packages/slate-plugins/src/elements/mention/components/MentionSelect.styles.ts
+++ b/packages/slate-plugins/src/elements/mention/components/MentionSelect.styles.ts
@@ -7,6 +7,7 @@ export const getStyles = (): MentionSelectStyles => {
       padding: '1px 3px',
       borderRadius: '3px',
       background: 'transparent',
+      cursor: 'pointer',
     },
   ];
 

--- a/packages/slate-plugins/src/elements/mention/components/MentionSelect.tsx
+++ b/packages/slate-plugins/src/elements/mention/components/MentionSelect.tsx
@@ -19,6 +19,7 @@ export const MentionSelectBase = ({
   options,
   valueIndex,
   styles,
+  onClickMention,
   ...props
 }: MentionSelectProps) => {
   const classNames = getClassNames(styles);
@@ -53,6 +54,10 @@ export const MentionSelectBase = ({
                 ? classNames.mentionItemSelected
                 : classNames.mentionItem
             }
+            onMouseDown={(e) => {
+              e.preventDefault();
+              onClickMention(editor, option);
+            }}
           >
             {option.value}
           </div>

--- a/packages/slate-plugins/src/elements/mention/components/MentionSelect.types.ts
+++ b/packages/slate-plugins/src/elements/mention/components/MentionSelect.types.ts
@@ -1,12 +1,17 @@
 import { IStyle, IStyleFunctionOrObject } from '@uifabric/merge-styles';
 import { MentionNodeData } from 'elements/mention/types';
 import { Range } from 'slate';
+import { ReactEditor } from 'slate-react';
 
 export interface MentionSelectProps {
   /**
    * Range from the mention trigger to the cursor
    */
   at: Range | null;
+  /**
+   * Called when clicking on a mention option
+   */
+  onClickMention: (editor: ReactEditor, option: MentionNodeData) => void;
   /**
    * List of mentionable items
    */

--- a/packages/slate-plugins/src/elements/mention/useMention.tsx
+++ b/packages/slate-plugins/src/elements/mention/useMention.tsx
@@ -3,7 +3,6 @@ import { isPointAtWordEnd, isWordAfterTrigger } from 'common/queries';
 import { getNextIndex } from 'elements/mention/utils/getNextIndex';
 import { getPreviousIndex } from 'elements/mention/utils/getPreviousIndex';
 import { Editor, Range, Transforms } from 'slate';
-import { ReactEditor } from 'slate-react';
 import { insertMention } from './transforms';
 import { MentionNodeData, UseMentionOptions } from './types';
 

--- a/packages/slate-plugins/src/elements/mention/useMention.tsx
+++ b/packages/slate-plugins/src/elements/mention/useMention.tsx
@@ -3,6 +3,7 @@ import { isPointAtWordEnd, isWordAfterTrigger } from 'common/queries';
 import { getNextIndex } from 'elements/mention/utils/getNextIndex';
 import { getPreviousIndex } from 'elements/mention/utils/getPreviousIndex';
 import { Editor, Range, Transforms } from 'slate';
+import { ReactEditor } from 'slate-react';
 import { insertMention } from './transforms';
 import { MentionNodeData, UseMentionOptions } from './types';
 
@@ -16,6 +17,17 @@ export const useMention = (
   const values = mentionables
     .filter((c) => c.value.toLowerCase().includes(search.toLowerCase()))
     .slice(0, maxSuggestions);
+
+  const onAddMention = useCallback(
+    (editor: Editor, option: MentionNodeData) => {
+      if (targetRange != null) {
+        Transforms.select(editor, targetRange);
+        insertMention(editor, option);
+        return setTargetRange(null);
+      }
+    },
+    [targetRange]
+  );
 
   const onKeyDownMention = useCallback(
     (e: any, editor: Editor) => {
@@ -35,9 +47,7 @@ export const useMention = (
 
         if (['Tab', 'Enter'].includes(e.key)) {
           e.preventDefault();
-          Transforms.select(editor, targetRange);
-          insertMention(editor, values[valueIndex]);
-          return setTargetRange(null);
+          return onAddMention(editor, values[valueIndex]);
         }
       }
     },
@@ -77,5 +87,6 @@ export const useMention = (
     values,
     onChangeMention,
     onKeyDownMention,
+    onAddMention,
   };
 };

--- a/stories/element/inline-void/mention.stories.tsx
+++ b/stories/element/inline-void/mention.stories.tsx
@@ -42,6 +42,7 @@ export const Example = () => {
     const editor = useMemo(() => pipe(createEditor(), ...withPlugins), []);
 
     const {
+      onAddMention,
       onChangeMention,
       onKeyDownMention,
       search,
@@ -70,7 +71,12 @@ export const Example = () => {
           onKeyDownDeps={[index, search, target]}
         />
 
-        <MentionSelect at={target} valueIndex={index} options={values} />
+        <MentionSelect
+          at={target}
+          valueIndex={index}
+          options={values}
+          onClickMention={onAddMention}
+        />
       </Slate>
     );
   };


### PR DESCRIPTION
Issue:
fixes #133 

## What I did
- added `onMouseDown` to `MentionSelectBase`
- exposed an `onAddMention` function from `useMention`
- which should be passed in to the `MentionSelect` when setting up the editor

It feels a bit hacky not using the `onClick`, but that messes up the `selection` in the editor somehow, so I looked at the `ToolbarButton` for inspiration, and that uses `onMouseDown` too.

## How to test
Click in the storybook when mention selection shows up.

<!--

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->