### PR TITLE
Make casing of sub/sup type consistent

### DIFF
--- a/packages/slate-plugins/src/marks/subscript/types.ts
+++ b/packages/slate-plugins/src/marks/subscript/types.ts
@@ -2,7 +2,7 @@ import { MarkPluginOptions, RenderLeafOptions } from 'mark';
 import { Text } from 'slate';
 import { RenderLeafProps } from 'slate-react';
 
-export const MARK_SUBSCRIPT = 'SUBSCRIPT';
+export const MARK_SUBSCRIPT = 'subscript';
 
 // Data of Text node
 export interface SubscriptNodeData {}

--- a/packages/slate-plugins/src/marks/superscript/types.ts
+++ b/packages/slate-plugins/src/marks/superscript/types.ts
@@ -2,7 +2,7 @@ import { MarkPluginOptions, RenderLeafOptions } from 'mark';
 import { Text } from 'slate';
 import { RenderLeafProps } from 'slate-react';
 
-export const MARK_SUPERSCRIPT = 'SUPERSCRIPT';
+export const MARK_SUPERSCRIPT = 'superscript';
 
 // Data of Text node
 export interface SuperscriptNodeData {}


### PR DESCRIPTION
## What I did

Fixed the casing of types for Superscript and Subscript plugin to make it consistent with rest of the types.
