### PR TITLE
Use mark html tag for highlights

### DIFF
--- a/packages/slate-plugins/src/marks/highlight/renderLeafHighlight.tsx
+++ b/packages/slate-plugins/src/marks/highlight/renderLeafHighlight.tsx
@@ -6,7 +6,7 @@ import {
   MARK_HIGHLIGHT,
 } from './types';
 
-const HighlightText = styled.span<{ bg: string }>`
+const HighlightText = styled.mark<{ bg: string }>`
   background-color: ${(props) => props.bg};
 `;
 


### PR DESCRIPTION
Use `<mark>` html tag for HighlightPlugin render.